### PR TITLE
docs(blog): fixed typo in the React (with jsx) example

### DIFF
--- a/website/blog/2019-02-08-Introducing-swc-1.0.md
+++ b/website/blog/2019-02-08-Introducing-swc-1.0.md
@@ -70,7 +70,7 @@ Swc implements almost all babel plugins. As of 1.0.0, swc can understand various
   "jsc": {
     "parser": {
       "syntax": "ecmascript",
-      "jsc": true
+      "jsx": true
     }
   }
 }


### PR DESCRIPTION
jsx instead of jsc