### PR TITLE
Replace broken introduction footer link

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -37,8 +37,8 @@ class Footer extends React.Component {
           </a>
           <div>
             <h5>Docs</h5>
-            <a href={this.docUrl('introduction.html', this.props.language)}>
-              Getting Started
+            <a href={this.docUrl('installation.html', this.props.language)}>
+              Installation
             </a>
             <a href={this.docUrl('configuring-swc.html', this.props.language)}>
               Configuring swc


### PR DESCRIPTION
The footer's 'introduction' link currently goes to a page that doesn't exist.

In the header, introduction goes to installation.
That's why I have replaced the link to be installation.