### PR TITLE
Bugfix -> server side rendering and broken links

### DIFF
--- a/website/blog/2019-02-08-Introducing-swc-1.0.md
+++ b/website/blog/2019-02-08-Introducing-swc-1.0.md
@@ -45,7 +45,7 @@ or
 yarn add --dev @swc/core
 ```
 
-See [installation guide](/docs/installation) for more details.
+See [installation guide](/docs) for more details.
 
 ## What is included in swc 1.0.0?
 
@@ -158,6 +158,6 @@ Also note that swc does not support custom plugin yet.
 
 Run `npm i --save-dev @swc/core @swc/cli` or `yarn add --dev @swc/core @swc/cli` to install. CLI apis of `@swc/cli` is almost equivalent to it of `@babel/cli`. So if you are using standartd ecmascript, you can just replace `npx babel` to `npx swc`. If it results in an error, please [report an error][issues].
 
-See [usage docs](/docs/usage-cli) and [migration docs](/docs/migrating-from-babel-cli) for more details. Also note that swc does not support custom plugin yet.
+See [usage docs](/docs/usage-swc-cli) and [migration docs](/docs/migrating-from-babel-cli) for more details. Also note that swc does not support custom plugin yet.
 
 [issues]: https://github.com/swc-project/swc/issues

--- a/website/blog/2020-08-07-swc-1.2.13.md
+++ b/website/blog/2020-08-07-swc-1.2.13.md
@@ -21,7 +21,7 @@ try {
 
 ### emitDecoratorMetadata for typescript decorators ([#939](https://github.com/swc-project/swc/pull/939))
 
-You can now use [nest][] with [swc]! You need to configure [swc] as shown in [the document](/docs/configuring-swc.html#jsctransformdecoratormetadata).
+You can now use [nest][] with [swc]! You need to configure [swc] as shown in [the document](/docs/configuring-swc#jsctransformdecoratormetadata).
 
 [swc]: https://github.com/swc-project/swc
 [nest]: https://nestjs.com/

--- a/website/src/components/GithubButton/index.tsx
+++ b/website/src/components/GithubButton/index.tsx
@@ -1,6 +1,4 @@
 import React, { useEffect, useRef } from "react";
-import { render as renderGH } from "github-buttons";
-
 interface GHButtonProps {
   title: string;
   href: string;
@@ -9,11 +7,13 @@ interface GHButtonProps {
 export function GithubButton(props: GHButtonProps) {
   const ref = useRef<HTMLAnchorElement>(null);
   useEffect(() => {
-    renderGH(ref.current, function (element: HTMLElement) {
-      if (!ref.current) {
-        return;
-      }
-      ref.current.parentNode.replaceChild(element, ref.current);
+    import(/* webpackMode: "eager" */ "github-buttons").then(({ render }) => {
+      render(ref.current, function (element: HTMLElement) {
+        if (!ref.current) {
+          return;
+        }
+        ref.current.parentNode.replaceChild(element, ref.current);
+      });
     });
   }, []);
 

--- a/website/src/components/HomeSplash/index.tsx
+++ b/website/src/components/HomeSplash/index.tsx
@@ -1,8 +1,8 @@
 import React from "react";
-import { GithubButton } from "../components/GithubButton";
-import { LinkButton } from "../components/LinkButton";
-import { DocusaurusProps, SWCSiteConfig } from "./index";
-import styles from "./common.module.css";
+import { DocusaurusProps, SWCSiteConfig } from "../../pages";
+import { GithubButton } from "../GithubButton";
+import { LinkButton } from "../LinkButton";
+import styles from "../../pages/common.module.css";
 
 export class HomeSplash extends React.Component<DocusaurusProps> {
   render() {

--- a/website/src/components/IndexPage/index.tsx
+++ b/website/src/components/IndexPage/index.tsx
@@ -1,12 +1,12 @@
 import React from "react";
-import { CommonProps } from "./index";
-import { HomeSplash } from "./HomeSplash";
-import { User } from "./users";
-import { Sponsors } from "../components/Sponsors";
-import { Features } from "../components/Features";
-import { UserComponent } from "../components/UserComponent";
-import { LinkButton } from "../components/LinkButton";
-import styles from "./common.module.css";
+import { CommonProps } from "../../pages";
+import { User } from "../../pages/users";
+import { Features } from "../Features";
+import { HomeSplash } from "../HomeSplash";
+import { LinkButton } from "../LinkButton";
+import { Sponsors } from "../Sponsors";
+import { UserComponent } from "../UserComponent";
+import styles from "../../pages/common.module.css";
 
 export class IndexPage extends React.Component<CommonProps> {
   render() {

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -8,8 +8,8 @@
 import React from "react";
 import Layout from "@theme/Layout";
 import { DocusaurusConfig } from "@docusaurus/types";
-import { IndexPage } from "./IndexPage";
 import { User } from "./users";
+import { IndexPage } from "../components/IndexPage";
 
 export interface SWCSiteConfig extends DocusaurusConfig {
   docsUrl?: string;


### PR DESCRIPTION
I found that if I run the production build commands locally there's a breakage caused in the `GithubButton`.

Because the import relies on `window`, this is not present during server side rendering and causes the build to fail.  I've wrapped it up into an async import so that this no longer fails.

There was also a failure because two items were in the `pages` folder that should have been in `components`, so I've fixed that too.

Finally, there were a couple of broken links in the the blog posts and I've fixed them up too.

