### PR TITLE
Feature proposal: Repl State as URLHash

### DIFF
--- a/src/components/Repl/urlHash.ts
+++ b/src/components/Repl/urlHash.ts
@@ -1,0 +1,28 @@
+interface ReplState {
+  rawCode?: string;
+  rawConfig?: string;
+}
+
+export const loadReplState: () => ReplState = function () {
+  const hash = window.location.hash.slice(1);
+  try {
+    return JSON.parse(decodeURIComponent(hash));
+  } catch {
+    return {};
+  }
+};
+
+export const saveReplState: (state: ReplState) => void = function (state) {
+  const hash = encodeURIComponent(JSON.stringify(state));
+  if (
+    typeof URL === "function" &&
+    typeof history === "object" &&
+    typeof history.replaceState === "function"
+  ) {
+    const url = new URL(location.href);
+    url.hash = hash;
+    history.replaceState(null, null, url);
+  } else {
+    location.hash = hash;
+  }
+};


### PR DESCRIPTION
## Motivation

[As the prettier playground does](https://prettier.io/playground/), I make Repl save Repl State(code, and config) as URL hash, and restore Repl State from urlhash on load.

Screen movie:

https://user-images.githubusercontent.com/42742053/129433578-3ee9e364-ca1e-4e83-b2dd-291360d118c6.mov



if a reporter can make a reproducible repl state and share its URL, we can reproduce it just by clicking that’s URL, so this function will make it easier to report and reproduce issues.

If you don’t think it is necessary, please be free to close this PR.