### PR TITLE
Fix: broken Repl with some error from swc

### DIFF
--- a/src/components/Repl/index.tsx
+++ b/src/components/Repl/index.tsx
@@ -91,7 +91,7 @@ export const Repl: React.FC<ReplProps> = () => {
         setCompiledCode(swcWasm.current.transformSync(rawCode, config).code);
         setCompileError(null);
       } catch (errorMessage) {
-        setCompileError(errorMessage);
+        setCompileError(errorMessage.toString());
       }
     }, DEBOUNCE_MS);
 


### PR DESCRIPTION
Fix: https://github.com/swc-project/swc/issues/2151

### Motivation

Some error message from swc breaks REPL and the page turn white. ErrorMessage state on REPL should be string | null,  error messages from swc could be string | Error, so React will be broken due to mismatch state type. I fixed it by stringify error before setState.