### PR TITLE
fix: broken doc links

### DIFF
--- a/docs/configuring-swc.md
+++ b/docs/configuring-swc.md
@@ -374,7 +374,7 @@ See https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-map
 
 > Requires swc@1.2.67
 
-See [the documentation for minification](./config-js-minify) for more details.
+See [the documentation for minification](/docs/config-js-minify) for more details.
 
 ## `jsc.experimental`
 
@@ -387,7 +387,7 @@ Reduce variable renaming of swc.
 
 ## module
 
-To configure module system, see the [docs](./config-js-module) for it.
+To configure module system, see the [docs](/docs/config-js-module) for it.
 
 ## minify
 

--- a/docs/usage-spack-cli.md
+++ b/docs/usage-spack-cli.md
@@ -10,7 +10,7 @@ sidebar_label: cli (spack)
 npm i --save-dev @swc/cli @swc/core
 ```
 
-Create a `spack.config.js` file. See [docs](./spack-basic) for more detail. Then, just run
+Create a `spack.config.js` file. See [docs](/docs/spack-basic) for more detail. Then, just run
 
 ```sh
 npx spack


### PR DESCRIPTION
The relative link will lead to create sub path under current path. e.g. `./config-js-minify` will become `/docs/configuring-swc/config-js-minify`. Convert them to abosulte paths