### PR TITLE
Update configuring swc doc

### DIFF
--- a/docs/configuring-swc.md
+++ b/docs/configuring-swc.md
@@ -99,15 +99,12 @@ _Note: you must add [`@swc/helpers`](https://www.npmjs.com/package/@swc/helpers)
 
 ## jsc.target
 
-Starting from `@swc/core` v1.0.27, you can specify the target environment for output code by using the `jsc.target` field.
-
-This will cause only the necessary transforms for the target environment to be applied when compiling the source code.
-
-For example: to disable transforms for es3/es5/es2015, set the target to `es2016` and only the transforms needed to support a es2016 and later runtime will be applied:
+Starting from @swc/core v1.0.27, you can specify the target environment by using the field.
 
 ```json
 {
   "jsc": {
+    // Disable es3 / es5 / es2015 transforms
     "target": "es2016"
   }
 }
@@ -218,7 +215,7 @@ This option can be overrided with `@jsxImportSource foo`.
 
 #### jsc.transform.react.pragma
 
-Replace the function used when compiling JSX expressions.
+When using `runtime: classic`, replaces the function used when compiling JSX expressions.
 
 Defaults to `React.createElement`.
 
@@ -242,7 +239,7 @@ Though the JSX spec allows this, it is disabled by default since React's JSX doe
 
 Toggles debug props `__self` and `__source` on elements generated from JSX, which are used by development tooling such as React Developer Tools.
 
-Automatically read `webpack` mode when used with `swc-loader`.
+This option is set automatically based on the Webpack `mode` setting when used with `swc-loader`. See [Using swc with webpack](/docs/usage-swc-loader/).
 
 #### jsc.transform.react.useBuiltins
 

--- a/docs/configuring-swc.md
+++ b/docs/configuring-swc.md
@@ -99,7 +99,7 @@ _Note: you must add [`@swc/helpers`](https://www.npmjs.com/package/@swc/helpers)
 
 ## jsc.target
 
-Starting from @swc/core v1.0.27, you can specify the target environment by using the field.
+Starting from `@swc/core` v1.0.27, you can specify the target environment by using the field.
 
 ```json
 {

--- a/docs/configuring-swc.md
+++ b/docs/configuring-swc.md
@@ -42,9 +42,13 @@ This is optional and defaults to
 
 ## jsc.externalHelpers
 
-You can use helpers from an external module named `@swc/helpers`.
+The output code may depend on helper functions to support the target environment. By default a helper function is inlined into the output files where it is required.
+
+You can use helpers from an external module by enabling `externalHelpers` and the helpers code will be imported by the output files from `node_modules/@swc/helpers`.
 
 While bundling, this option will greatly reduce your file size.
+
+_Note: you must add [`@swc/helpers`](https://www.npmjs.com/package/@swc/helpers) as a dependency in addition to `@swc/core`._
 
 ```json
 {
@@ -95,12 +99,15 @@ While bundling, this option will greatly reduce your file size.
 
 ## jsc.target
 
-Starting from `@swc/core` v1.0.27, you can specify the target environment by using the field.
+Starting from `@swc/core` v1.0.27, you can specify the target environment for output code by using the `jsc.target` field.
+
+This will cause only the necessary transforms for the target environment to be applied when compiling the source code.
+
+For example: to disable transforms for es3/es5/es2015, set the target to `es2016` and only the transforms needed to support a es2016 and later runtime will be applied:
 
 ```json
 {
   "jsc": {
-    // Disable es3 / es5 / es2015 transforms
     "target": "es2016"
   }
 }
@@ -108,7 +115,9 @@ Starting from `@swc/core` v1.0.27, you can specify the target environment by usi
 
 ## jsc.loose
 
-Starting from `@swc/core` v1.1.4, you can enable loose mode by
+Starting from `@swc/core` v1.1.4, you can enable "loose" transformations by enabling `jsc.loose` which works like `babel-preset-env` loose mode.
+
+See https://2ality.com/2015/12/babel6-loose-mode.html
 
 ```json
 {
@@ -117,8 +126,6 @@ Starting from `@swc/core` v1.1.4, you can enable loose mode by
   }
 }
 ```
-
-In loose mode, swc generates more efficient code.
 
 ## jsc.transform
 
@@ -149,9 +156,9 @@ Example
 
 ### jsc.transform.legacyDecorator
 
-You can use legacy decorators with `swc`. To enable legacy decorator, set `jsc.transform.legacyDecorator` and `jsc.parser.decorators` to true.
+You can use the legacy (stage 1) class decorators syntax and behaviour.
 
-e.g.
+To enable legacy decorators, set `jsc.transform.legacyDecorator` and `jsc.parser.decorators` to true.
 
 ```json
 {
@@ -192,47 +199,60 @@ Note: This feature requires `v1.2.13+`.
 
 ### jsc.transform.react
 
-- `runtime`
+#### jsc.transform.react.runtime
 
-Possible values: `automatic`, `classic`.
+Possible values: `automatic`, `classic`. This affects how JSX source code will be compiled.
 
-Use `automatic` to use new jsx runtimes.
+- Use `runtime: automatic` to use a JSX runtime module (e.g. `react/jsx-runtime` introduced in React 17).
+- Use `runtime: classic` to use `React.createElement` instead - with this option, you must ensure that `React` is in scope when using JSX.
 
-- `importSource`
+See https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html
 
-Only for `runtime: automatic`. `react` by default.
+#### jsc.transform.react.importSource
+
+When using `runtime: automatic`, determines the runtime library to import.
+
+Defaults to `react`.
 
 This option can be overrided with `@jsxImportSource foo`.
 
-Determines the runtime library to import.
+#### jsc.transform.react.pragma
 
-- `pragma`
-  Replace the function used when compiling JSX expressions.
-
-This option can be overrided with `@jsx foo`.
+Replace the function used when compiling JSX expressions.
 
 Defaults to `React.createElement`.
 
-- `pragmaFrag`
-  Replace the component used when compiling JSX fragments.
+This option can be overrided with `@jsx foo`.
 
-This option can be overrided with `@jsxFrag foo`.
+#### jsc.transform.react.pragmaFrag
+
+Replace the component used when compiling JSX fragments.
 
 Defaults to `React.Fragment`
 
-- `throwIfNamespace`
-  Toggles whether or not to throw an error if an XML namespaced tag name is used. For example: `<f:image />`
+This option can be overrided with `@jsxFrag foo`.
+
+#### jsc.transform.react.throwIfNamespace
+
+Toggles whether or not to throw an error if an XML namespaced tag name is used. For example: `<f:image />`
 
 Though the JSX spec allows this, it is disabled by default since React's JSX does not currently have support for it.
 
-- `development`
-  Toggles plugins that aid in development, such as `jsx-self` and `jsx-source`. Automatically read `webpack` mode when used with `swc-loader`
+#### jsc.transform.react.development
 
-- `useBuiltins`
-  Use `Object.assign()` instead of `_extends`. Defaults to false.
+Toggles debug props `__self` and `__source` on elements generated from JSX, which are used by development tooling such as React Developer Tools.
 
-- `refresh`
-  Enable [react-refresh](https://www.npmjs.com/package/react-refresh) related transform. Defaults to false as it's considered experimental. Pass true or object to enable this feature.
+Automatically read `webpack` mode when used with `swc-loader`.
+
+#### jsc.transform.react.useBuiltins
+
+Use `Object.assign()` instead of `_extends`. Defaults to false.
+
+#### jsc.transform.react.refresh
+
+Enable [react-refresh](https://www.npmjs.com/package/react-refresh) related transform. Defaults to false as it's considered experimental.
+
+Pass `refresh: true` to enable this feature, or an object with the following:
 
 ```ts
 interface ReactRefreshConfig {

--- a/docs/usage-swc-loader.md
+++ b/docs/usage-swc-loader.md
@@ -26,3 +26,9 @@ module: {
   ];
 }
 ```
+
+### React development
+
+The [`jsc.transform.react.development`](/docs/configuring-swc#jsctransformreact) option is set automatically based on the Webpack `mode`.
+
+See https://webpack.js.org/configuration/mode/


### PR DESCRIPTION
@kdy1 I have proposed quite a few changes here, please let me know your thoughts and I will try to respond to feedback fully. 🙏 

My overall goal is to provide additional context for each configuration property and to reduce the assumption that the reader already knows how Babel works before using swc.

The result is more verbose, but with greater clarity and so it will be quicker to understand and move on despite there being more words on the page.

I would like to follow-up on this and improve clarity on some other properties such as `keepClassNames` and `paths` and `baseUrl` - and to add a few words on the sections which currently only contain a code snippet such as `jsc.parser`.