### PR TITLE
Fix typo in inlineSourcesContent option name

### DIFF
--- a/docs/configuring-swc.md
+++ b/docs/configuring-swc.md
@@ -515,15 +515,15 @@ Example:
 }
 ```
 
-## `inlineSourceContents`
+## `inlineSourcesContent`
 
-If you want to make `swc` inline source map contents, you can set `inlineSourceContents` to true.
+If you want to make `swc` inline source map contents, you can set `inlineSourcesContent` to true.
 
 Example:
 
 ```json
 {
   "sourceMaps": true,
-  "inlineSourceContents": true
+  "inlineSourcesContent": true
 }
 ```


### PR DESCRIPTION
The name of this option is not the same as in the code: https://github.com/swc-project/swc/blob/master/node-swc/src/types.ts#L429