### PR TITLE
Update Shopify link to the canonical URL

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -42,7 +42,7 @@ module.exports = {
       {
         caption: "Shopify",
         image: "/img/users/shopify.svg",
-        infoLink: "https://www.shopify.ca/",
+        infoLink: "https://www.shopify.com/",
         pinned: false,
       },
       {


### PR DESCRIPTION
https://www.shopify.ca/brand-assets

> Where used on a web page, our brand assets, as well as the mention of our name, should include embedded hyperlinks to our homepage: www.shopify.com.