### PR TITLE
fix: typo in spack docs

### DIFF
--- a/docs/spack-basic.md
+++ b/docs/spack-basic.md
@@ -86,7 +86,7 @@ module.exports = config({
 
 You can change destination directory of the bundler using `output`.
 
-#### Exmaple
+#### Example
 
 ```ts
 const { config } = require("@swc/core/spack");


### PR DESCRIPTION
Exmaple -> Example.

(I accidentally cloned the `swc` repo thinking docs lived there; a few "Exmaple" in there too - not sure if its worth a PR?)