### PR TITLE
Fix address of blog link

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -40,7 +40,7 @@ SWC can be used for both compilation and bundling. For compilation, it takes Jav
 </Callout>
 
 <div className="mt-16 mb-20 text-center">
-  [Get Started](/docs/getting-started) · [Playground](/playground) · [Blog](/blog) · [Rustdocs](https://rustdoc.swc.rs/swc/) · [GitHub Repository](https://github.com/swc-project/swc) · [Donate](https://opencollective.com/swc)
+  [Get Started](/docs/getting-started) · [Playground](/playground) · [Blog](/blog/perf-swc-vs-babel) · [Rustdocs](https://rustdoc.swc.rs/swc/) · [GitHub Repository](https://github.com/swc-project/swc) · [Donate](https://opencollective.com/swc)
 </div>
 
 ## Overview


### PR DESCRIPTION
Or should we add`/blog` to `redirects` in `next.config.js` ?