### PR TITLE
Fix: allow playground iframe to write clipboard

### DIFF
--- a/pages/playground/index.md
+++ b/pages/playground/index.md
@@ -13,6 +13,6 @@ full: true
     background: 'rgb(21, 21, 21)'
   }}
   title="SWC Playground"
-  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+  allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking; clipboard-write"
   sandbox="allow-autoplay allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
 />


### PR DESCRIPTION
## Motivation :fire:

In Chrome, a website should specify the `allow` policy to allow cross-origin websites in iframe to write clipboard.

https://sites.google.com/a/chromium.org/dev/Home/chromium-security/deprecating-permissions-in-cross-origin-iframes

https://web.dev/async-clipboard/#permissions-policy-integration

Currently, pushing `share button` causes DOMException Error with the stable chrome.


![スクリーンショット 2021-11-21 17 39 12](https://user-images.githubusercontent.com/42742053/142755566-6dc09fbf-f411-458f-ab0d-3f2a5e45066f.png)

