### PR TITLE
FIx typo

### DIFF
--- a/pages/docs/configuration/supported-browsers.mdx
+++ b/pages/docs/configuration/supported-browsers.mdx
@@ -118,4 +118,4 @@ Define ES features to skip to reduce bundle size. For example, your `.swcrc` cou
 - `exclude`: (_string[]_) can be a `core-js` module (`es.math.sign`) or an SWC pass (`transform-spread`).
 - `coreJs`: (_string_) defaults to `undefined`. The version of `core-js` to use.
 - `shippedProposals`: (_boolean_) defaults to `false`.
-- `forceAllTransforms`: (_boolean_) defaults to `false`. Enable all transforms possible.
+- `forceAllTransforms`: (_boolean_) defaults to `false`. Enable all possible transforms.

--- a/pages/docs/configuration/supported-browsers.mdx
+++ b/pages/docs/configuration/supported-browsers.mdx
@@ -118,4 +118,4 @@ Define ES features to skip to reduce bundle size. For example, your `.swcrc` cou
 - `exclude`: (_string[]_) can be a `core-js` module (`es.math.sign`) or an SWC pass (`transform-spread`).
 - `coreJs`: (_string_) defaults to `undefined`. The version of `core-js` to use.
 - `shippedProposals`: (_boolean_) defaults to `false`.
-- `forceAllTransforms`: (_boolean_) defaults to `false`.Eenable all transforms possible.
+- `forceAllTransforms`: (_boolean_) defaults to `false`. Enable all transforms possible.


### PR DESCRIPTION
Before: `.Eenable all transforms possible.`
After: `. Enable all possible transforms.`