### PR TITLE
Fix Benchmarks Select Background Color

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -47,3 +47,7 @@ article > main + div a.font-semibold {
 .dark .invert-on-dark {
   filter: invert(1) brightness(1.8);
 }
+
+.dark .docs-container select {
+  background: rgba(17, 17, 17, 1);
+}


### PR DESCRIPTION
It fixes benchmarks's select button background color when dark mode is on.

Before:
![Before](https://i.imgur.com/iIsM4hI.png)

After:
![After](https://i.imgur.com/F26m4l7.png)