### PR TITLE
docs(): Add documentation for use with babel-loader

### DIFF
--- a/pages/docs/usage/swc-loader.md
+++ b/pages/docs/usage/swc-loader.md
@@ -28,3 +28,24 @@ module: {
 ### React Development
 
 The [`jsc.transform.react.development`](/docs/configuration/compilation#jsctransformreactdevelopment) option is automatically set based on the [webpack `mode`](https://webpack.js.org/configuration/mode/).
+
+### With babel-loader
+
+When used with babel-loader, the parseMap option must be set to true.
+
+```js
+module: {
+  rules: [
+    {
+      test: /\.m?js$/,
+      exclude: /(node_modules)/,
+      use: {
+        loader: "swc-loader",
+        options: {
+          parseMap: true
+        }
+      }
+    }
+  ];
+}
+```


### PR DESCRIPTION
Add that the parseMap option must be set when swc-loader and babel-loader are used together.

preview: https://website-ljc123qxn-swc-project.vercel.app/docs/usage/swc-loader#with-babel-loader
reference: https://github.com/swc-project/swc-loader/pull/13