### PR TITLE
docs(core): add parse functions

### DIFF
--- a/pages/docs/usage/core.md
+++ b/pages/docs/usage/core.md
@@ -43,6 +43,43 @@ Returns `Promise<{ code: string, map?: string }>`
 
 Returns `{ code: string, map?: string }`
 
+## parse
+
+Returns `Promise<Module>`
+
+```js
+const swc = require('@swc/core')
+
+swc
+  .parse("source code", {
+    syntax: "ecmascript", // "ecmascript" | "typesscript"
+    comments: false,
+    script: true,
+
+    // Defaults to es3
+    target: "es3",
+
+    // Input files are treated as module by default
+    isModule: false,
+  })
+  .then((module) => {
+    module.type // file type
+    module.body; // AST
+  })
+```
+
+### parseSync
+
+Returns `Script | Module`
+
+### parseFile
+
+Returns `Promise<Script | Module>`
+
+### parseFileSync
+
+Returns `Script | Module`
+
 ## Options
 
 This still needs to be documented. Contributions welcome!

--- a/pages/docs/usage/core.md
+++ b/pages/docs/usage/core.md
@@ -59,7 +59,7 @@ swc
     // Defaults to es3
     target: "es3",
 
-    // Input files are treated as module by default
+    // Input source code are treated as module by default
     isModule: false,
   })
   .then((module) => {


### PR DESCRIPTION
documenting `parse` functions

I read the d.ts file that found out these functions