### PR TITLE
Fix GitHub icon link to not target shuding/nextra

### DIFF
--- a/theme.config.js
+++ b/theme.config.js
@@ -8,7 +8,7 @@ const Vercel = ({ height = 20 }) => (
 );
 
 export default {
-  github: "https://github.com/swc-project/swc",
+  projectLink: "https://github.com/swc-project/swc",
   docsRepositoryBase: "https://github.com/swc-project/website/blob/master",
   titleSuffix: " – SWC",
   search: true,


### PR DESCRIPTION
![Developer tools shows the GitHub icon is a href="https://github.com/shuding/nextra"](https://user-images.githubusercontent.com/3071003/165333589-7bc8108f-1ded-4729-b8bb-6c6372f65bc4.png)

Seems [`projectLink`](https://nextra.vercel.app/themes/docs/configuration#projectlink) is recommended option, not `github`.