### PR TITLE
Remove horizontal scroll in index page

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -23,7 +23,7 @@ body {
 }
 {<h1 className="text-center font-extrabold md:text-5xl mt-8">SWC</h1>}
 
-<Bleed full>
+<Bleed>
     <div className="mx-auto max-w-full w-[880px] text-center px-4 mb-10">
       <p className="text-lg mb-2 text-gray-600 md:!text-2xl">
         Rust-based platform for the Web


### PR DESCRIPTION
Currently `<Bleed full />` extends width to 100vw. When "Always show scrollbars"-like options are enabled by a browser/OS, 100vw makes horizontal scrollbar. And seems swc.rs website doesn't need `Bleed` at all.