### PR TITLE
show an example of using the schema field

### DIFF
--- a/pages/docs/configuration/modules.mdx
+++ b/pages/docs/configuration/modules.mdx
@@ -10,6 +10,7 @@ To emit a CommonJS module, change the `type` in `.swcrc`:
 
 ```json
 {
+  "$schema": "http://json.schemastore.org/swcrc",
   "module": {
     "type": "commonjs",
 


### PR DESCRIPTION
Using JSON schema helps with configuring SWC in IDEs that support schema completion