### PR TITLE
fix: typo in mangle options for class names and functions

### DIFF
--- a/pages/docs/configuration/minification.mdx
+++ b/pages/docs/configuration/minification.mdx
@@ -119,8 +119,8 @@ Similar to [the mangle option](https://terser.org/docs/api-reference.html#mangle
 
 - `properties`, Defaults to `false`, and `true` is identical to `{}`.
 - `topLevel`, Defaults to `true`. Aliased as `toplevel` for compatibility with `terser`.
-- `keepClassnames`, Defaults to `false`. Aliased as `keep_classnames` for compatibility with `terser`.
-- `keepFnames`, Defaults to `false`.
+- `keepClassNames`, Defaults to `false`. Aliased as `keep_classnames` for compatibility with `terser`.
+- `keepFnNames`, Defaults to `false`.
 - `keepPrivateProps`, Defaults to `false`. Aliased as `keep_private_props` for compatibility with `terser`.
 - `reserved`, Defaults to `[]`
 - `ie8`, Ignored.


### PR DESCRIPTION
Fixes #166 