### PR TITLE
docs: align install commands for examples

### DIFF
--- a/pages/blog/swc-1.mdx
+++ b/pages/blog/swc-1.mdx
@@ -40,13 +40,11 @@ It's 16x - 20x faster than babel even on single-core synchronous benchmark. Note
 You can install `swc` with
 
 ```sh
-npm install --save-dev @swc/core
-```
+# if you use npm
+npm i -D @swc/core
 
-or
-
-```sh
-yarn add --dev @swc/core
+# if you use yarn
+yarn add -D @swc/core
 ```
 
 See [Getting Started](/docs/getting-started) for more details.

--- a/pages/docs/usage/cli.md
+++ b/pages/docs/usage/cli.md
@@ -5,7 +5,11 @@
 Run the following to download pre-built binaries:
 
 ```plaintext
+# if you use npm
 npm i -D @swc/cli @swc/core
+
+# if you use yarn
+yarn add -D @swc/cli @swc/core
 ```
 
 Then, you can transpile your files:

--- a/pages/docs/usage/swc-loader.md
+++ b/pages/docs/usage/swc-loader.md
@@ -6,10 +6,10 @@ This module allows you to use SWC with webpack.
 
 ```plaintext
 # if you use npm
-npm i --save-dev @swc/core swc-loader
+npm i -D @swc/core swc-loader
 
 # if you use yarn
-yarn add -D jest @swc/core swc-loader
+yarn add -D @swc/core swc-loader
 ```
 
 ## Usage

--- a/pages/docs/usage/swc-loader.md
+++ b/pages/docs/usage/swc-loader.md
@@ -5,7 +5,11 @@ This module allows you to use SWC with webpack.
 ## Installation
 
 ```plaintext
+# if you use npm
 npm i --save-dev @swc/core swc-loader
+
+# if you use yarn
+yarn add -D jest @swc/core swc-loader
 ```
 
 ## Usage


### PR DESCRIPTION
Jest example is showing npm and yarn option. Might help others if this is shown in all examples.