### PR TITLE
[Docs] Update regex examples in configuration/compilation

### DIFF
--- a/pages/docs/configuration/compilation.md
+++ b/pages/docs/configuration/compilation.md
@@ -420,13 +420,13 @@ annotations.
 ```json
 [
   {
-    "test": ".*.js$",
+    "test": ".*\\.js$",
     "module": {
       "type": "commonjs"
     }
   },
   {
-    "test": ".*.ts$",
+    "test": ".*\\.ts$",
     "module": {
       "type": "amd"
     }
@@ -440,7 +440,7 @@ Note that `test` option can be used to transcompile only typescript files, like
 
 ```json
 {
-  "test": ".*.ts$",
+  "test": ".*\\.ts$",
   "jsc": {
     "parser": {
       "syntax": "typescript",
@@ -458,7 +458,7 @@ Type: `Regex / Regex[]`
 
 ```json
 {
-  "test": ".*.ts$",
+  "test": ".*\\.ts$",
   "jsc": {
     "parser": {
       "syntax": "typescript",
@@ -476,7 +476,7 @@ Type: `Regex / Regex[]`
 
 ```json
 {
-  "exclude": [".*.js$", ".*.map$"],
+  "exclude": [".*\\.js$", ".*\\.map$"],
   "jsc": {
     "parser": {
       "syntax": "typescript",


### PR DESCRIPTION
The current examples, e.g `".*.js$"` can match a file named `index.js` but also a file named `indexjs` (without the extension), this is a minor thing but it's not the ideal regex to match against unless the dot is escaped.