### PR TITLE
Add "Discord" to text on line 31.

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -28,7 +28,7 @@ body {
   </p>}
 </div>
 
-SWC is an extensible Rust-based platform for the next generation of fast developer tools. It's used by tools like Next.js, Parcel, and Deno, as well as companies like Vercel, ByteDance, Tencent, Shopify, and more.
+SWC is an extensible Rust-based platform for the next generation of fast developer tools. It's used by tools like Next.js, Parcel, and Deno, as well as companies like Vercel, ByteDance, Tencent, Shopify, Discord, and more.
 
 SWC can be used for both compilation and bundling. For compilation, it takes JavaScript / TypeScript files using modern JavaScript features and outputs valid code that is supported by all major browsers.
 


### PR DESCRIPTION
As of September 26. The company "Discord" has started using SWC instead of Babel. And i just went ahead and added "Discord" to text on line 31.