### PR TITLE
Update `supported-browsers.mdx`

### DIFF
--- a/pages/docs/configuration/supported-browsers.mdx
+++ b/pages/docs/configuration/supported-browsers.mdx
@@ -24,7 +24,7 @@ Starting with `v1.1.10`, you can now use `browserslist` to automatically configu
 
 `string | Array<string> | { [string]: string }`, defaults to `{}`.
 
-Describes the environments you support/target for your project. This can either be a [browserslist-compatible](https://github.com/ai/browserslist) query:
+Describes the environments you support/target for your project. This can either be a [browserslist-compatible](https://github.com/ai/browserslist) query [(with limitations)](https://github.com/browserslist/browserslist-rs#limitations):
 
 ```json
 {


### PR DESCRIPTION
swc supports [browserslist](https://github.com/browserslist/browserslist) queries via [browserslist-rs](https://github.com/browserslist/browserslist-rs) however it does not support the full [browserslist](https://github.com/browserslist/browserslist#queries) syntax:

https://github.com/browserslist/browserslist-rs#limitations

The docs do not make this clear which could be misleading.

For example in my organisation we have centralised browserslist configuration via the `extends browserslist-config-mycompany` syntax which is not supported by swc (via browserslist-rs).