### PR TITLE
Update minification.mdx

### DIFF
--- a/pages/docs/configuration/minification.mdx
+++ b/pages/docs/configuration/minification.mdx
@@ -64,7 +64,7 @@ Similar to [the compress option](https://terser.org/docs/api-reference.html#comp
 - `hoist_vars`, defaults to `false`.
 - `ie8`, Ignored.
 - `if_return`, defaults to `true`.
-- `inline`, defaults to ``.
+- `inline`, defaults to `true`.
 - `join_vars`, defaults to `true`.
 - `keep_classnames`, defaults to `false`.
 - `keep_fargs`, defaults to `false`.

--- a/pages/docs/configuration/minification.mdx
+++ b/pages/docs/configuration/minification.mdx
@@ -76,7 +76,7 @@ Similar to [the compress option](https://terser.org/docs/api-reference.html#comp
 - `pure_getters`, defaults to ``.
 - `pure_funcs`, defaults to `[]`. Type is an array of string.
 - `reduce_funcs`, defaults to `false`.
-- `reduce_vars`, defaults to `false`.
+- `reduce_vars`, defaults to `true`.
 - `sequences`, defaults to `true`.
 - `side_effects`, defaults to `true`.
 - `switches`, defaults to `true`.


### PR DESCRIPTION
The currently set default value for `reduce_vars` and `inline` are incorrect, based on the code (https://github.com/swc-project/swc/blob/0376da73c6113ade5945321b7c3abe257ce3b83c/crates/swc_ecma_minifier/src/option/terser.rs) it goes to the value of defaults, so it should be `true`. 

As it also mimics the behavior of Terser, the API reference of terser also sets it to true: https://terser.org/docs/api-reference.html#compress-options
```
reduce_vars (default: true) -- Improve optimization on variables assigned with and used as constant values.
...
inline (default: true) -- inline calls to function with simple/return statement:
```