### PR TITLE
Fix property name in minification mangle

### DIFF
--- a/pages/docs/configuration/minification.mdx
+++ b/pages/docs/configuration/minification.mdx
@@ -121,7 +121,7 @@ Similar to [the mangle option](https://terser.org/docs/api-reference.html#mangle
 
 - `properties`, Defaults to `false`, and `true` is identical to `{}`.
 - `topLevel`, Defaults to `true`. Aliased as `toplevel` for compatibility with `terser`.
-- `keepClassnames`, Defaults to `false`. Aliased as `keep_classnames` for compatibility with `terser`.
+- `keepClassNames`, Defaults to `false`. Aliased as `keep_classnames` for compatibility with `terser`.
 - `keepFnames`, Defaults to `false`.
 - `keepPrivateProps`, Defaults to `false`. Aliased as `keep_private_props` for compatibility with `terser`.
 - `reserved`, Defaults to `[]`


### PR DESCRIPTION
`keepClassnames` not working. `keepClassNames` is the correct one. Received error:
```
unknown field `keepClassnames`, expected one of `props`, `topLevel`, `keepClassNames`, `keepFnNames`, `keepPrivateProps`, `ie8`, `safari10`, `reserved`
```