### PR TITLE
Fix property names in minification mangle

### DIFF
--- a/pages/docs/configuration/minification.mdx
+++ b/pages/docs/configuration/minification.mdx
@@ -119,10 +119,10 @@ Similar to [the mangle option](https://terser.org/docs/api-reference.html#mangle
 }
 ```
 
-- `properties`, Defaults to `false`, and `true` is identical to `{}`.
+- `props`, Defaults to `false`, and `true` is identical to `{}`.
 - `topLevel`, Defaults to `true`. Aliased as `toplevel` for compatibility with `terser`.
 - `keepClassNames`, Defaults to `false`. Aliased as `keep_classnames` for compatibility with `terser`.
-- `keepFnames`, Defaults to `false`.
+- `keepFnNames`, Defaults to `false`.
 - `keepPrivateProps`, Defaults to `false`. Aliased as `keep_private_props` for compatibility with `terser`.
 - `reserved`, Defaults to `[]`
 - `ie8`, Ignored.


### PR DESCRIPTION
Follow-up on #206 . `keepFnNames` and `props` instead of `keepFnNames` and `properties`. Previously I received error:
```
unknown field `keepClassnames`, expected one of `props`, `topLevel`, `keepClassNames`, `keepFnNames`, `keepPrivateProps`, `ie8`, `safari10`, `reserved`
```