### PR TITLE
fix add new packages with pnpm in "getting-started.mdx"

### DIFF
--- a/pages/docs/getting-started.mdx
+++ b/pages/docs/getting-started.mdx
@@ -12,7 +12,7 @@ Otherwise, run the following to download pre-built binaries:
 <Tabs items={['pnpm', 'npm', 'yarn']}>
   <Tab>
     ```bash
-    pnpm i -D @swc/cli @swc/core
+    pnpm add -D @swc/cli @swc/core
     ```
   </Tab>
     <Tab>


### PR DESCRIPTION
With **pnpm** to install new packages `pnpm add` should be used. [pnpm doc](https://pnpm.io/cli/add)