### PR TITLE
docs: mention default JSX runtime is "classic"

### DIFF
--- a/pages/docs/configuration/compilation.md
+++ b/pages/docs/configuration/compilation.md
@@ -335,6 +335,7 @@ If you are using typescript and decorators with `emitDecoratorMetadata` enabled,
 
 Possible values: `automatic`, `classic`. This affects how JSX source code will be compiled.
 
+- Defauts to `classic`.
 - Use `runtime: automatic` to use a JSX runtime module (e.g. `react/jsx-runtime` introduced in React 17).
 - Use `runtime: classic` to use `React.createElement` instead - with this option, you must ensure that `React` is in scope when using JSX.
 


### PR DESCRIPTION
Listing "automatic" as the first enum value led me to think it was the default value, because no default value was documented. 

But the default value is "classic" according to the v1 code here: https://github.com/swc-project/swc/blob/main/crates/swc_ecma_transforms_react/src/jsx/mod.rs#L40

I think it's valuable to document the default value. Default values are documented for other options.