### PR TITLE
feat(/): change link from Twitter to GitHub

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -110,7 +110,7 @@ SWC is designed to be extensible. Currently, there is support for:
   </div>
 </div>
 
-SWC is created by [kdy1dev](https://github.com/kdy1).
+SWC is created by [kdy1](https://github.com/kdy1).
 Follow [@kdy1dev](https://twitter.com/kdy1dev) on Twitter for future project updates.
 
 Feel free to join the [discussions on GitHub](https://github.com/swc-project/swc/discussions)!

--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -110,7 +110,7 @@ SWC is designed to be extensible. Currently, there is support for:
   </div>
 </div>
 
-SWC is created by [kdy1dev](https://twitter.com/kdy1dev).
+SWC is created by [kdy1dev](https://github.com/kdy1).
 Follow [@kdy1dev](https://twitter.com/kdy1dev) on Twitter for future project updates.
 
 Feel free to join the [discussions on GitHub](https://github.com/swc-project/swc/discussions)!


### PR DESCRIPTION
On the section, It provides same Twitter link in duplicate so I changed it to GitHub link for providing more information of creator.