### PR TITLE
feat: updates CLI docs adding new `strip-leading-paths` parameter

### DIFF
--- a/pages/docs/usage/cli.mdx
+++ b/pages/docs/usage/cli.mdx
@@ -194,3 +194,11 @@ npx swc input.js --log-watch-compilation
 ### --extensions
 
 Use specific extensions.
+
+### --strip-leading-paths
+
+Remove the leading directory (including all parent relative paths) when building the final output path. As an example it compiles all modules under `src` folder to `dist` folder, without create the `src` folder inside of `dist`.
+
+```sh
+npx swc src -d dist --strip-leading-paths
+```


### PR DESCRIPTION
Related to [this PR](https://github.com/swc-project/cli/pull/283) 

This PR introduces the `strip-leading-paths` command to the `cli` section on the docs.  This was a recent change and was undocumented in the docs, but very important.