### PR TITLE
docs: ensure that the baseUrl must be an absolute path

### DIFF
--- a/pages/docs/configuration/compilation.mdx
+++ b/pages/docs/configuration/compilation.mdx
@@ -546,6 +546,8 @@ Requires `jsc.baseUrl`. See below.
 
 ## jsc.baseUrl
 
+The path must be specified as an absolute path.
+
 [Learn more](https://www.typescriptlang.org/docs/handbook/module-resolution.html#base-url).
 
 ## jsc.minify


### PR DESCRIPTION
Based on the following error:

```sh
[Error: failed to handle: base_dir(`.`) must be absolute. Please ensure that `jsc.baseUrl` is specified correctly. This cannot be deduced by SWC itself because SWC is a transpiler and it does not try to resolve project details.
```

Added to docs to ensure that the baseUrl must be absolute.