### PR TITLE
docs: add tip for Rspack builtin:swc-loader

### DIFF
--- a/pages/docs/usage/swc-loader.mdx
+++ b/pages/docs/usage/swc-loader.mdx
@@ -4,6 +4,8 @@ import { Callout, Tabs, Tab } from 'nextra-theme-docs'
 
 This module allows you to use SWC with webpack.
 
+For Rspack users, you can use Rspack's [builtin:swc-loader](https://rspack.dev/guide/features/builtin-swc-loader), without the need to install the swc-loader package.
+
 ## Installation
 
 <Tabs items={['pnpm', 'npm', 'yarn']}>


### PR DESCRIPTION
Add a tip  for using Rspack builtin:swc-loader with SWC

> For Rspack users, you can use Rspack's [builtin:swc-loader](https://rspack.dev/guide/features/builtin-swc-loader), without the need to install the swc-loader package.
