### PR TITLE
core.mdx: Add "unknown" value to JSMinifyOptions module

### DIFF
--- a/pages/docs/usage/core.mdx
+++ b/pages/docs/usage/core.mdx
@@ -198,7 +198,7 @@ export interface JsMinifyOptions {
     ecma?: TerserEcmaVersion;
     keep_classnames?: boolean;
     keep_fnames?: boolean;
-    module?: boolean;
+    module?: boolean | "unknown";
     safari10?: boolean;
     toplevel?: boolean;
     sourceMap?: boolean;


### PR DESCRIPTION
Hey folks! 👋

https://github.com/swc-project/swc/pull/9026 added a new value to the `module` property in `JSMinifyOptions`, but the type declaration in `core.mdx` was not updated.

This change fixes that.

Please let me know if I missed anything!