### PR TITLE
fix: link to bundling example using spack

### DIFF
--- a/pages/docs/usage/bundling.mdx
+++ b/pages/docs/usage/bundling.mdx
@@ -10,7 +10,7 @@ SWC is able to bundle multiple JavaScript or TypeScript files into one.
 
 This feature is currently named `spack`, but will be renamed to `swcpack` in `v2`. `spack.config.js` will be deprecated for `swcpack.config.js`.
 
-View a [basic example of bundling](https://github.com/swc-project/cli/tree/master/examples/spack-basic).
+View a [basic example of bundling](https://github.com/swc-project/pkgs/tree/main/packages/cli/examples/spack-basic).
 
 ## Usage
 


### PR DESCRIPTION
The `cli` package and its examples was moved. This PR fixes the link to its new location.