### PR TITLE
docs: fix typo in @swc/wasm-typescript

### DIFF
--- a/pages/docs/references/wasm-typescript.mdx
+++ b/pages/docs/references/wasm-typescript.mdx
@@ -1,5 +1,4 @@
-/# `@swc/wasm-typescript`
-
+# @swc/wasm-typescript
 
 ## Installation
 


### PR DESCRIPTION
URL: https://swc.rs/docs/references/wasm-typescript

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td><img width="734" alt="Screenshot 2024-07-29 at 14 35 12" src="https://github.com/user-attachments/assets/0f8d4662-3538-4322-ba49-8fce67f83101"></td>
<td><img width="734" alt="Screenshot 2024-07-29 at 14 35 29" src="https://github.com/user-attachments/assets/74acc3f1-f6f9-4f91-8cf8-24cad96cb128">
</td>
</tr>
</table>