### PR TITLE
fix(docs): use `pnpm add <pkg>` instead of `pnpm install <pkg>`

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -59,7 +59,7 @@ SWC can be downloaded and used as a pre-built binary, or built from source. Curr
 <Tabs items={['pnpm', 'npm', 'yarn']}>
   <Tab>
     ```bash copy
-    pnpm i -D @swc/cli @swc/core
+    pnpm add -D @swc/cli @swc/core
     ```
   </Tab>
   <Tab>


### PR DESCRIPTION
It should be `pnpm add <pkg>` instead of `pnpm install <pkg>`.

`pnpm install` is used to install all dependencies for a project while `pnpm add <pkg>` is used to install a package and any packages that it depends on.

More info (official source):

- https://pnpm.io/cli/add
- https://pnpm.io/cli/install

---

`pnpm install <pkg>` does the same as `pnpm add <pkg>` today, but it might stop functioning that way in future versions since the official docs clarify the difference between the two. It might be that `pnpm install <pkg>` was used in past versions, and the PNPM team didn't want to remove support for it right away after introducing `pnpm add <pkg>`.