### PR TITLE
Update the companies using SWC

### DIFF
--- a/pages/index.mdx
+++ b/pages/index.mdx
@@ -28,7 +28,7 @@ body {
   </p>}
 </div>
 
-SWC is an extensible Rust-based platform for the next generation of fast developer tools. It's used by tools like Next.js, Parcel, and Deno, as well as companies like Vercel, ByteDance, Tencent, Shopify, and more.
+SWC is an extensible Rust-based platform for the next generation of fast developer tools. It's used by tools like Next.js, Parcel, and Deno, as well as companies like Vercel, ByteDance, Tencent, Shopify, Trip.com, and more.
 
 SWC can be used for both compilation and bundling. For compilation, it takes JavaScript / TypeScript files using modern JavaScript features and outputs valid code that is supported by all major browsers.
 

--- a/theme.config.js
+++ b/theme.config.js
@@ -44,14 +44,14 @@ const Head = () => {
         name="description"
         content={
           frontMatter?.description ||
-          "SWC is an extensible Rust-based platform for the next generation of fast developer tools. It's used by tools like Next.js, Parcel, and Deno, as well as companies like Vercel, ByteDance, Tencent, Shopify, and more."
+          "SWC is an extensible Rust-based platform for the next generation of fast developer tools. It's used by tools like Next.js, Parcel, and Deno, as well as companies like Vercel, ByteDance, Tencent, Shopify, Trip.com, and more."
         }
       />
       <meta
         name="og:description"
         content={
           frontMatter.description ||
-          "SWC is an extensible Rust-based platform for the next generation of fast developer tools. It's used by tools like Next.js, Parcel, and Deno, as well as companies like Vercel, ByteDance, Tencent, Shopify, and more."
+          "SWC is an extensible Rust-based platform for the next generation of fast developer tools. It's used by tools like Next.js, Parcel, and Deno, as well as companies like Vercel, ByteDance, Tencent, Shopify, Trip.com, and more."
         }
       />
       <meta name="twitter:card" content="summary_large_image" />


### PR DESCRIPTION
Dear SWC Team,

I am an employee at [Trip.com](https://www.trip.com), and I would like to submit a PR to include Trip.com in the "Who’s using?" section on the SWC website. At Trip.com, we have integrated SWC into our end-to-end (e2e) testing processes, particularly by leveraging our custom [swc-plugin-canyon](https://github.com/canyon-project/canyon/tree/main/plugins/swc-plugin-canyon).

Canyon is a JavaScript code coverage tool tailored for e2e testing. Initially, we developed `babel-plugin-canyon` and `vite-plugin-canyon` to serve our coverage needs. However, after realizing that several of our internal applications built with [Next.js](https://nextjs.org) were using SWC, we extended our solution with [swc-plugin-canyon](https://github.com/canyon-project/canyon/tree/main/plugins/swc-plugin-canyon). This plugin allows us to detect environment variables in our CI pipeline and report code coverage data alongside e2e results, which are then displayed on our internal server.

We are excited to share our use case for SWC at [Trip.com](https://www.trip.com), and we truly appreciate the contributions of the SWC team to the developer community.

Thank you for your consideration.
