### PR TITLE
bump to nextra v2.2

### DIFF
--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -14,8 +14,8 @@
     "focus-visible": "^5.2.0",
     "markdown-to-jsx": "^6.11.4",
     "next": "^13.0.6",
-    "nextra": "2.0.1",
-    "nextra-theme-docs": "2.0.1",
+    "nextra": "2.2.20",
+    "nextra-theme-docs": "2.2.20",
     "react": "^18.2.0",
     "react-chartjs-2": "^3.3.0",
     "react-dom": "^18.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -309,11 +309,11 @@ importers:
         specifier: ^13.0.6
         version: 13.0.6(react-dom@18.2.0)(react@18.2.0)
       nextra:
-        specifier: 2.0.1
-        version: 2.0.1(next@13.0.6)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 2.2.20
+        version: 2.2.20(next@13.0.6)(react-dom@18.2.0)(react@18.2.0)
       nextra-theme-docs:
-        specifier: 2.0.1
-        version: 2.0.1(next@13.0.6)(react-dom@18.2.0)(react@18.2.0)
+        specifier: 2.2.20
+        version: 2.2.20(next@13.0.6)(nextra@2.2.20)(react-dom@18.2.0)(react@18.2.0)
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -465,6 +465,16 @@ packages:
     resolution:
       {
         integrity: sha512-4zpTHZ9Cm6L9L+uIqghQX8ZXg8HKFcjYO3qHoO8zTmRm6HQUJ8SSJ+KRvbMBZn0EGVlT4DRYeQ/6hjlyXBh+Kg==,
+      }
+    engines: { node: ">=6.9.0" }
+    dependencies:
+      regenerator-runtime: 0.14.1
+    dev: false
+
+  /@babel/runtime@7.26.0:
+    resolution:
+      {
+        integrity: sha512-FDSOghenHTiToteC/QRlv2q3DhPZ/oOXTBoirfWNx1Cx3TMVcGWQtMMmQcSvb/JjpNeGzx8Pq/b4fKEJuWm1sw==,
       }
     engines: { node: ">=6.9.0" }
     dependencies:
@@ -1729,7 +1739,7 @@ packages:
         integrity: sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==,
       }
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
     dev: false
 
   /@radix-ui/number@1.1.0:
@@ -1745,7 +1755,7 @@ packages:
         integrity: sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==,
       }
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
     dev: false
 
   /@radix-ui/primitive@1.1.0:
@@ -1832,7 +1842,7 @@ packages:
       "@types/react-dom":
         optional: true
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       "@radix-ui/react-primitive": 1.0.3(@types/react-dom@18.2.18)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)
       "@types/react": 18.3.3
       "@types/react-dom": 18.2.18
@@ -1992,7 +2002,7 @@ packages:
       "@types/react-dom":
         optional: true
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       "@radix-ui/react-compose-refs": 1.0.1(@types/react@18.3.3)(react@18.2.0)
       "@radix-ui/react-context": 1.0.1(@types/react@18.3.3)(react@18.2.0)
       "@radix-ui/react-primitive": 1.0.3(@types/react-dom@18.2.18)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)
@@ -2041,7 +2051,7 @@ packages:
       "@types/react":
         optional: true
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       "@types/react": 18.3.3
       react: 18.2.0
     dev: false
@@ -2103,7 +2113,7 @@ packages:
       "@types/react":
         optional: true
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       "@types/react": 18.3.3
       react: 18.2.0
     dev: false
@@ -2173,7 +2183,7 @@ packages:
       "@types/react":
         optional: true
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       "@types/react": 18.3.3
       react: 18.2.0
     dev: false
@@ -2210,7 +2220,7 @@ packages:
       "@types/react-dom":
         optional: true
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       "@radix-ui/primitive": 1.0.1
       "@radix-ui/react-compose-refs": 1.0.1(@types/react@18.3.3)(react@18.2.0)
       "@radix-ui/react-primitive": 1.0.3(@types/react-dom@18.2.18)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)
@@ -2291,7 +2301,7 @@ packages:
       "@types/react":
         optional: true
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       "@types/react": 18.3.3
       react: 18.2.0
     dev: false
@@ -2328,7 +2338,7 @@ packages:
       "@types/react-dom":
         optional: true
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       "@radix-ui/react-compose-refs": 1.0.1(@types/react@18.3.3)(react@18.2.0)
       "@radix-ui/react-primitive": 1.0.3(@types/react-dom@18.2.18)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)
       "@radix-ui/react-use-callback-ref": 1.0.1(@types/react@18.3.3)(react@18.2.0)
@@ -2407,7 +2417,7 @@ packages:
       "@types/react":
         optional: true
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       "@radix-ui/react-use-layout-effect": 1.0.1(@types/react@18.3.3)(react@18.2.0)
       "@types/react": 18.3.3
       react: 18.2.0
@@ -2470,7 +2480,7 @@ packages:
       "@types/react-dom":
         optional: true
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       "@radix-ui/primitive": 1.0.1
       "@radix-ui/react-collection": 1.0.3(@types/react-dom@18.2.18)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)
       "@radix-ui/react-compose-refs": 1.0.1(@types/react@18.3.3)(react@18.2.0)
@@ -2619,7 +2629,7 @@ packages:
       "@types/react-dom":
         optional: true
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       "@floating-ui/react-dom": 2.1.2(react-dom@18.2.0)(react@18.2.0)
       "@radix-ui/react-arrow": 1.0.3(@types/react-dom@18.2.18)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)
       "@radix-ui/react-compose-refs": 1.0.1(@types/react@18.3.3)(react@18.2.0)
@@ -2684,7 +2694,7 @@ packages:
       "@types/react-dom":
         optional: true
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       "@radix-ui/react-primitive": 1.0.3(@types/react-dom@18.2.18)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)
       "@types/react": 18.3.3
       "@types/react-dom": 18.2.18
@@ -2732,7 +2742,7 @@ packages:
       "@types/react-dom":
         optional: true
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       "@radix-ui/react-compose-refs": 1.0.1(@types/react@18.3.3)(react@18.2.0)
       "@radix-ui/react-use-layout-effect": 1.0.1(@types/react@18.3.3)(react@18.2.0)
       "@types/react": 18.3.3
@@ -2757,7 +2767,7 @@ packages:
       "@types/react-dom":
         optional: true
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       "@radix-ui/react-slot": 1.0.2(@types/react@18.3.3)(react@18.2.0)
       "@types/react": 18.3.3
       "@types/react-dom": 18.2.18
@@ -2862,7 +2872,7 @@ packages:
       "@types/react-dom":
         optional: true
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       "@radix-ui/primitive": 1.0.1
       "@radix-ui/react-collection": 1.0.3(@types/react-dom@18.2.18)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)
       "@radix-ui/react-compose-refs": 1.0.1(@types/react@18.3.3)(react@18.2.0)
@@ -3054,7 +3064,7 @@ packages:
       "@types/react":
         optional: true
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       "@radix-ui/react-compose-refs": 1.0.1(@types/react@18.3.3)(react@18.2.0)
       "@types/react": 18.3.3
       react: 18.2.0
@@ -3274,7 +3284,7 @@ packages:
       "@types/react":
         optional: true
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       "@types/react": 18.3.3
       react: 18.2.0
     dev: false
@@ -3307,7 +3317,7 @@ packages:
       "@types/react":
         optional: true
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       "@radix-ui/react-use-callback-ref": 1.0.1(@types/react@18.3.3)(react@18.2.0)
       "@types/react": 18.3.3
       react: 18.2.0
@@ -3342,7 +3352,7 @@ packages:
       "@types/react":
         optional: true
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       "@radix-ui/react-use-callback-ref": 1.0.1(@types/react@18.3.3)(react@18.2.0)
       "@types/react": 18.3.3
       react: 18.2.0
@@ -3377,7 +3387,7 @@ packages:
       "@types/react":
         optional: true
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       "@types/react": 18.3.3
       react: 18.2.0
     dev: false
@@ -3410,7 +3420,7 @@ packages:
       "@types/react":
         optional: true
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       "@types/react": 18.3.3
       react: 18.2.0
     dev: false
@@ -3443,7 +3453,7 @@ packages:
       "@types/react":
         optional: true
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       "@radix-ui/rect": 1.0.1
       "@types/react": 18.3.3
       react: 18.2.0
@@ -3478,7 +3488,7 @@ packages:
       "@types/react":
         optional: true
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       "@radix-ui/react-use-layout-effect": 1.0.1(@types/react@18.3.3)(react@18.2.0)
       "@types/react": 18.3.3
       react: 18.2.0
@@ -3517,7 +3527,7 @@ packages:
       "@types/react-dom":
         optional: true
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       "@radix-ui/react-primitive": 1.0.3(@types/react-dom@18.2.18)(@types/react@18.3.3)(react-dom@18.2.0)(react@18.2.0)
       "@types/react": 18.3.3
       "@types/react-dom": 18.2.18
@@ -3554,7 +3564,7 @@ packages:
         integrity: sha512-fyrgCaedtvMg9NK3en0pnOYJdtfwxUcNolezkNPUsoX57X8oQk+NkqcvzHXD2uKNij6GXmWU9NDru2IWjrO4BQ==,
       }
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
     dev: false
 
   /@radix-ui/rect@1.1.0:
@@ -3579,40 +3589,10 @@ packages:
       tslib: 2.8.0
     dev: false
 
-  /@reach/skip-nav@0.17.0(react-dom@18.2.0)(react@18.2.0):
-    resolution:
-      {
-        integrity: sha512-wkkpQK3ffczzGHis6TaUvpOabuAL9n9Kh5vr4h56XPIJP3X77VcHUDk7MK3HbV1mTgamGxc9Hbd1sXKSWLu3yA==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || 17.x
-      react-dom: ^16.8.0 || 17.x
-    dependencies:
-      "@reach/utils": 0.17.0(react-dom@18.2.0)(react@18.2.0)
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      tslib: 2.8.0
-    dev: false
-
   /@reach/utils@0.16.0(react-dom@18.2.0)(react@18.2.0):
     resolution:
       {
         integrity: sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==,
-      }
-    peerDependencies:
-      react: ^16.8.0 || 17.x
-      react-dom: ^16.8.0 || 17.x
-    dependencies:
-      react: 18.2.0
-      react-dom: 18.2.0(react@18.2.0)
-      tiny-warning: 1.0.3
-      tslib: 2.8.0
-    dev: false
-
-  /@reach/utils@0.17.0(react-dom@18.2.0)(react@18.2.0):
-    resolution:
-      {
-        integrity: sha512-M5y8fCBbrWeIsxedgcSw6oDlAMQDkl5uv3VnMVJ7guwpf4E48Xlh1v66z/1BgN/WYe2y8mB/ilFD2nysEfdGeA==,
       }
     peerDependencies:
       react: ^16.8.0 || 17.x
@@ -3995,6 +3975,13 @@ packages:
       }
     dev: true
 
+  /@types/js-yaml@4.0.9:
+    resolution:
+      {
+        integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==,
+      }
+    dev: false
+
   /@types/json-schema@7.0.15:
     resolution:
       {
@@ -4011,6 +3998,20 @@ packages:
       "@types/node": 18.11.10
     dev: true
     optional: true
+
+  /@types/katex@0.14.0:
+    resolution:
+      {
+        integrity: sha512-+2FW2CcT0K3P+JMR8YG846bmDwplKUTsWgT2ENwdQ1UdVfRk3GQrh6Mi4sTopy30gI8Uau5CEqHTDZ6YvWIUPA==,
+      }
+    dev: false
+
+  /@types/katex@0.16.7:
+    resolution:
+      {
+        integrity: sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ==,
+      }
+    dev: false
 
   /@types/lodash-es@4.17.12:
     resolution:
@@ -4251,6 +4252,13 @@ packages:
       }
     engines: { node: ">=12" }
 
+  /ansi-sequence-parser@1.1.1:
+    resolution:
+      {
+        integrity: sha512-vJXt3yiaUL4UU546s3rPXlsry/RnM730G1+HkpKE012AN0sx1eOrxSu95oKDIonskeLTijMgqWZ3uDEe3NFvyg==,
+      }
+    dev: false
+
   /ansi-styles@3.2.1:
     resolution:
       {
@@ -4333,7 +4341,6 @@ packages:
       {
         integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==,
       }
-    dev: true
 
   /aria-hidden@1.2.4:
     resolution:
@@ -4804,7 +4811,6 @@ packages:
         integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==,
       }
     engines: { node: ">= 12" }
-    dev: true
 
   /commander@9.5.0:
     resolution:
@@ -4814,10 +4820,10 @@ packages:
     engines: { node: ^12.20.0 || >=14 }
     dev: true
 
-  /compute-scroll-into-view@1.0.20:
+  /compute-scroll-into-view@3.1.0:
     resolution:
       {
-        integrity: sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg==,
+        integrity: sha512-rj8l8pD4bJ1nx+dAkMhV1xB5RuZEyVysfxJqB1pRchh1KVvwOv9b7CGB8ZfjTImVv2oF+sYMUkMZq6Na5Ftmbg==,
       }
     dev: false
 
@@ -5188,7 +5194,7 @@ packages:
         integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==,
       }
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       csstype: 3.1.3
     dev: false
 
@@ -5247,6 +5253,14 @@ packages:
       {
         integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==,
       }
+
+  /entities@4.5.0:
+    resolution:
+      {
+        integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==,
+      }
+    engines: { node: ">=0.12" }
+    dev: false
 
   /error-ex@1.3.2:
     resolution:
@@ -5458,13 +5472,6 @@ packages:
       "@types/estree-jsx": 1.0.5
       estree-util-is-identifier-name: 2.1.0
       estree-walker: 3.0.3
-    dev: false
-
-  /estree-util-is-identifier-name@1.1.0:
-    resolution:
-      {
-        integrity: sha512-OVJZ3fGGt9By77Ix9NhaRbzfbDV/2rx9EP7YIDJTmsZSEc5kYn2vWcNccYyahJL2uAQZK2a5Or2i0wtIKTPoRQ==,
-      }
     dev: false
 
   /estree-util-is-identifier-name@2.1.0:
@@ -5824,10 +5831,10 @@ packages:
       git-up: 7.0.0
     dev: false
 
-  /github-slugger@1.5.0:
+  /github-slugger@2.0.0:
     resolution:
       {
-        integrity: sha512-wIh+gKBI9Nshz2o46B0B3f5k/W+WI9ZAv6y5Dn5WJ5SK1t0TnDimB4WE5rmTD05ZAIn8HALCZVmCsvj0w0v0lw==,
+        integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==,
       }
     dev: false
 
@@ -5970,6 +5977,18 @@ packages:
     engines: { node: ">=8" }
     dev: true
 
+  /hash-obj@4.0.0:
+    resolution:
+      {
+        integrity: sha512-FwO1BUVWkyHasWDW4S8o0ssQXjvyghLV2rfVhnN36b2bbcj45eGiuzdn9XOvOpjV3TKQD7Gm2BWNXdE9V4KKYg==,
+      }
+    engines: { node: ">=12" }
+    dependencies:
+      is-obj: 3.0.0
+      sort-keys: 5.1.0
+      type-fest: 1.4.0
+    dev: false
+
   /hasown@2.0.2:
     resolution:
       {
@@ -5978,6 +5997,75 @@ packages:
     engines: { node: ">= 0.4" }
     dependencies:
       function-bind: 1.1.2
+
+  /hast-util-from-dom@4.2.0:
+    resolution:
+      {
+        integrity: sha512-t1RJW/OpJbCAJQeKi3Qrj1cAOLA0+av/iPFori112+0X7R3wng+jxLA+kXec8K4szqPRGI8vPxbbpEYvvpwaeQ==,
+      }
+    dependencies:
+      hastscript: 7.2.0
+      web-namespaces: 2.0.1
+    dev: false
+
+  /hast-util-from-html-isomorphic@1.0.0:
+    resolution:
+      {
+        integrity: sha512-Yu480AKeOEN/+l5LA674a+7BmIvtDj24GvOt7MtQWuhzUwlaaRWdEPXAh3Qm5vhuthpAipFb2vTetKXWOjmTvw==,
+      }
+    dependencies:
+      "@types/hast": 2.3.10
+      hast-util-from-dom: 4.2.0
+      hast-util-from-html: 1.0.2
+      unist-util-remove-position: 4.0.2
+    dev: false
+
+  /hast-util-from-html@1.0.2:
+    resolution:
+      {
+        integrity: sha512-LhrTA2gfCbLOGJq2u/asp4kwuG0y6NhWTXiPKP+n0qNukKy7hc10whqqCFfyvIA1Q5U5d0sp9HhNim9gglEH4A==,
+      }
+    dependencies:
+      "@types/hast": 2.3.10
+      hast-util-from-parse5: 7.1.2
+      parse5: 7.2.1
+      vfile: 5.3.7
+      vfile-message: 3.1.4
+    dev: false
+
+  /hast-util-from-parse5@7.1.2:
+    resolution:
+      {
+        integrity: sha512-Nz7FfPBuljzsN3tCQ4kCBKqdNhQE2l0Tn+X1ubgKBPRoiDIu1mL08Cfw4k7q71+Duyaw7DXDN+VTAp4Vh3oCOw==,
+      }
+    dependencies:
+      "@types/hast": 2.3.10
+      "@types/unist": 2.0.11
+      hastscript: 7.2.0
+      property-information: 6.5.0
+      vfile: 5.3.7
+      vfile-location: 4.1.0
+      web-namespaces: 2.0.1
+    dev: false
+
+  /hast-util-is-element@2.1.3:
+    resolution:
+      {
+        integrity: sha512-O1bKah6mhgEq2WtVMk+Ta5K7pPMqsBBlmzysLdcwKVrqzZQ0CHqUPiIVspNhAG1rvxpvJjtGee17XfauZYKqVA==,
+      }
+    dependencies:
+      "@types/hast": 2.3.10
+      "@types/unist": 2.0.11
+    dev: false
+
+  /hast-util-parse-selector@3.1.1:
+    resolution:
+      {
+        integrity: sha512-jdlwBjEexy1oGz0aJ2f4GKMaVKkA9jwjr4MjAAI22E5fM/TXVZHuS5OpONtdeIkRKqAaryQ2E9xNQxijoThSZA==,
+      }
+    dependencies:
+      "@types/hast": 2.3.10
+    dev: false
 
   /hast-util-to-estree@2.3.3:
     resolution:
@@ -6004,11 +6092,16 @@ packages:
       - supports-color
     dev: false
 
-  /hast-util-to-string@1.0.4:
+  /hast-util-to-text@3.1.2:
     resolution:
       {
-        integrity: sha512-eK0MxRX47AV2eZ+Lyr18DCpQgodvaS3fAQO2+b9Two9F5HEoRPhiUMNzoXArMJfZi2yieFzUBMRl3HNJ3Jus3w==,
+        integrity: sha512-tcllLfp23dJJ+ju5wCCZHVpzsQQ43+moJbqVX3jNWPB7z/KFC4FyZD6R7y94cHL6MQ33YtMZL8Z0aIXXI4XFTw==,
       }
+    dependencies:
+      "@types/hast": 2.3.10
+      "@types/unist": 2.0.11
+      hast-util-is-element: 2.1.3
+      unist-util-find-after: 4.0.1
     dev: false
 
   /hast-util-whitespace@2.0.1:
@@ -6016,6 +6109,19 @@ packages:
       {
         integrity: sha512-nAxA0v8+vXSBDt3AnRUNjyRIQ0rD+ntpbAp4LnPkumc5M9yUbSMa4XDU9Q6etY4f1Wp4bNgvc1yjiZtsTTrSng==,
       }
+    dev: false
+
+  /hastscript@7.2.0:
+    resolution:
+      {
+        integrity: sha512-TtYPq24IldU8iKoJQqvZOuhi5CyCQRAbvDOX0x1eW6rsHSxa/1i2CCiptNTotGHJ3VoHRGmqiv6/D3q113ikkw==,
+      }
+    dependencies:
+      "@types/hast": 2.3.10
+      comma-separated-tokens: 2.0.3
+      hast-util-parse-selector: 3.1.1
+      property-information: 6.5.0
+      space-separated-tokens: 2.0.2
     dev: false
 
   /hex-color-regex@1.1.0:
@@ -6299,6 +6405,14 @@ packages:
       }
     engines: { node: ">=0.12.0" }
 
+  /is-obj@3.0.0:
+    resolution:
+      {
+        integrity: sha512-IlsXEHOjtKhpN8r/tRFj2nDyTmHvcfNeu/nrRIcXE17ROeatXchkojffa1SpdqW4cr/Fj6QkEf/Gn4zf6KKvEQ==,
+      }
+    engines: { node: ">=12" }
+    dev: false
+
   /is-plain-obj@3.0.0:
     resolution:
       {
@@ -6412,7 +6526,6 @@ packages:
     hasBin: true
     dependencies:
       argparse: 2.0.1
-    dev: true
 
   /json-buffer@3.0.1:
     resolution:
@@ -6468,6 +6581,16 @@ packages:
     optionalDependencies:
       graceful-fs: 4.2.11
     dev: true
+
+  /katex@0.16.11:
+    resolution:
+      {
+        integrity: sha512-RQrI8rlHY92OLf3rho/Ts8i/XvjgguEjOkO1BEXcU3N8BqPpSzBNwV/G0Ukr+P/l3ivvJUE/Fa/CwbS6HesGNQ==,
+      }
+    hasBin: true
+    dependencies:
+      commander: 8.3.0
+    dev: false
 
   /keyv@4.5.4:
     resolution:
@@ -6598,6 +6721,13 @@ packages:
       }
     dev: false
 
+  /lodash.get@4.4.2:
+    resolution:
+      {
+        integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==,
+      }
+    dev: false
+
   /lodash.merge@4.6.2:
     resolution:
       {
@@ -6717,7 +6847,7 @@ packages:
         integrity: sha512-jfZW7cWS5y/1xswZo8VBOdudUiSd9nifYRWphc9M5D/ee4w4AoXLgBEdRbgVaxbMuagBPeUC5y2Hi8DO6o9aDg==,
       }
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       remove-accents: 0.5.0
     dev: false
 
@@ -6838,6 +6968,17 @@ packages:
       mdast-util-to-markdown: 1.5.0
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /mdast-util-math@2.0.2:
+    resolution:
+      {
+        integrity: sha512-8gmkKVp9v6+Tgjtq6SYx9kGPpTf6FVYRa53/DLh479aldR9AyP48qeVOgNZ5X7QUK7nOy4yw7vg6mbiGcs9jWQ==,
+      }
+    dependencies:
+      "@types/mdast": 3.0.15
+      longest-streak: 3.1.0
+      mdast-util-to-markdown: 1.5.0
     dev: false
 
   /mdast-util-mdx-expression@1.3.2:
@@ -7087,6 +7228,21 @@ packages:
       micromark-extension-gfm-task-list-item: 1.0.5
       micromark-util-combine-extensions: 1.1.0
       micromark-util-types: 1.1.0
+    dev: false
+
+  /micromark-extension-math@2.1.2:
+    resolution:
+      {
+        integrity: sha512-es0CcOV89VNS9wFmyn+wyFTKweXGW4CEvdaAca6SWRWPyYCbBisnjaHLjWO4Nszuiud84jCpkHsqAJoa768Pvg==,
+      }
+    dependencies:
+      "@types/katex": 0.16.7
+      katex: 0.16.11
+      micromark-factory-space: 1.1.0
+      micromark-util-character: 1.2.0
+      micromark-util-symbol: 1.1.0
+      micromark-util-types: 1.1.0
+      uvu: 0.5.6
     dev: false
 
   /micromark-extension-mdx-expression@1.0.8:
@@ -7549,6 +7705,26 @@ packages:
       react: 18.2.0
     dev: false
 
+  /next-mdx-remote@4.4.1(react-dom@18.2.0)(react@18.2.0):
+    resolution:
+      {
+        integrity: sha512-1BvyXaIou6xy3XoNF4yaMZUCb6vD2GTAa5ciOa6WoO+gAUTYsb1K4rI/HSC2ogAWLrb/7VSV52skz07vOzmqIQ==,
+      }
+    engines: { node: ">=14", npm: ">=7" }
+    peerDependencies:
+      react: ">=16.x <=18.x"
+      react-dom: ">=16.x <=18.x"
+    dependencies:
+      "@mdx-js/mdx": 2.3.0
+      "@mdx-js/react": 2.3.0(react@18.2.0)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      vfile: 5.3.7
+      vfile-matter: 3.0.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /next-seo@5.15.0(next@13.0.6)(react-dom@18.2.0)(react@18.2.0):
     resolution:
       {
@@ -7716,39 +7892,39 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /nextra-theme-docs@2.0.1(next@13.0.6)(react-dom@18.2.0)(react@18.2.0):
+  /nextra-theme-docs@2.2.20(next@13.0.6)(nextra@2.2.20)(react-dom@18.2.0)(react@18.2.0):
     resolution:
       {
-        integrity: sha512-vrxSQjfG5hcWXd0foVUgRu1T9rD+dQdVnKzJhpEG+ncAIYTT/o7GajvYUEPPZMYvvZwehmNIUhSTDN9unnVsxw==,
+        integrity: sha512-YbDbpwvLCUnDvq9afP57Zu/fDFbSrsvx5MEZIhKRcrn/eCfo4yIwoMMhdRF0yntB5uTDc4MZ8jqJgb25g2v7QA==,
       }
     peerDependencies:
       next: ">=9.5.3"
+      nextra: 2.2.20
       react: ">=16.13.1"
       react-dom: ">=16.13.1"
     dependencies:
       "@headlessui/react": 1.7.19(react-dom@18.2.0)(react@18.2.0)
-      "@mdx-js/react": 2.3.0(react@18.2.0)
       "@popperjs/core": 2.11.8
-      "@reach/skip-nav": 0.17.0(react-dom@18.2.0)(react@18.2.0)
       clsx: 1.2.1
       flexsearch: 0.7.43
       focus-visible: 5.2.0
       git-url-parse: 13.1.1
-      github-slugger: 1.5.0
       intersection-observer: 0.12.2
       match-sorter: 6.3.4
       next: 13.0.6(react-dom@18.2.0)(react@18.2.0)
       next-seo: 5.15.0(next@13.0.6)(react-dom@18.2.0)(react@18.2.0)
       next-themes: 0.2.1(next@13.0.6)(react-dom@18.2.0)(react@18.2.0)
+      nextra: 2.2.20(next@13.0.6)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      scroll-into-view-if-needed: 2.2.31
+      scroll-into-view-if-needed: 3.1.0
+      zod: 3.23.8
     dev: false
 
-  /nextra@2.0.1(next@13.0.6)(react-dom@18.2.0)(react@18.2.0):
+  /nextra@2.2.20(next@13.0.6)(react-dom@18.2.0)(react@18.2.0):
     resolution:
       {
-        integrity: sha512-IOBwqMREnadxGryNHvwr3sZuD90uyaTxCWi9yxDB56UndsLBTulKwXNIOdW1FV+vKTbSGpz89wNe665Moli7Kw==,
+        integrity: sha512-V5P5UHvA7GvISziJSEMVV9jCDBm1aMlez3XqKPzvr/aIrugfnIPBhGrFh2YjpXp5FspldgTS8lbZVf36Alonhg==,
       }
     peerDependencies:
       next: ">=9.5.3"
@@ -7756,21 +7932,29 @@ packages:
       react-dom: ">=16.13.1"
     dependencies:
       "@mdx-js/mdx": 2.3.0
+      "@mdx-js/react": 2.3.0(react@18.2.0)
       "@napi-rs/simple-git": 0.1.19
-      github-slugger: 1.5.0
+      github-slugger: 2.0.0
       graceful-fs: 4.2.11
       gray-matter: 4.0.3
+      katex: 0.16.11
+      lodash.get: 4.4.2
       next: 13.0.6(react-dom@18.2.0)(react@18.2.0)
+      next-mdx-remote: 4.4.1(react-dom@18.2.0)(react@18.2.0)
+      p-limit: 3.1.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      rehype-mdx-title: 1.0.0
-      rehype-pretty-code: 0.2.4(shiki@0.10.1)
+      rehype-katex: 6.0.3
+      rehype-pretty-code: 0.9.3(shiki@0.14.7)
       remark-gfm: 3.0.1
+      remark-math: 5.1.1
       remark-reading-time: 2.0.1
-      shiki: 0.10.1
+      shiki: 0.14.7
       slash: 3.0.0
       title: 3.5.3
+      unist-util-remove: 3.1.1
       unist-util-visit: 4.1.2
+      zod: 3.23.8
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -7965,7 +8149,6 @@ packages:
     engines: { node: ">=10" }
     dependencies:
       yocto-queue: 0.1.0
-    dev: true
 
   /p-locate@5.0.0:
     resolution:
@@ -8055,6 +8238,15 @@ packages:
       }
     dependencies:
       parse-path: 7.0.0
+    dev: false
+
+  /parse5@7.2.1:
+    resolution:
+      {
+        integrity: sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==,
+      }
+    dependencies:
+      entities: 4.5.0
     dev: false
 
   /path-equal@1.2.5:
@@ -8670,7 +8862,7 @@ packages:
       react: ">=16.6.0"
       react-dom: ">=16.6.0"
     dependencies:
-      "@babel/runtime": 7.25.9
+      "@babel/runtime": 7.26.0
       dom-helpers: 5.2.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
@@ -8782,29 +8974,32 @@ packages:
     engines: { node: ">=8" }
     dev: true
 
-  /rehype-mdx-title@1.0.0:
+  /rehype-katex@6.0.3:
     resolution:
       {
-        integrity: sha512-5B/53Y+KQHm4/nrE6pIIPc9Ie2fbPMCLs8WwMGYWWHr+5g3TkmEijRkr8TGYHULtc+C7bOoPR8LIF5DpGROIDg==,
+        integrity: sha512-ByZlRwRUcWegNbF70CVRm2h/7xy7jQ3R9LaY4VVSvjnoVWwWVhNL60DiZsBpC5tSzYQOCvDbzncIpIjPZWodZA==,
       }
-    engines: { node: ">=12.2.0" }
     dependencies:
-      estree-util-is-identifier-name: 1.1.0
-      hast-util-to-string: 1.0.4
-      unist-util-visit: 2.0.3
+      "@types/hast": 2.3.10
+      "@types/katex": 0.14.0
+      hast-util-from-html-isomorphic: 1.0.0
+      hast-util-to-text: 3.1.2
+      katex: 0.16.11
+      unist-util-visit: 4.1.2
     dev: false
 
-  /rehype-pretty-code@0.2.4(shiki@0.10.1):
+  /rehype-pretty-code@0.9.3(shiki@0.14.7):
     resolution:
       {
-        integrity: sha512-vbqwIa4cNwRaVur9caUw/b0jOQR88Svrs9c9RaQoogvbBxs5X9bWrSe5oFypaRTTq2cpZ45YzJQ7UUPO76LMKA==,
+        integrity: sha512-57i+ifrttqpeQxub0NZ2pRw0aiUPYeBpr234NLWfZ4BfbEaP+29+iCXB1rUMkzoPi6IBC4w4I93mUPgw36IajQ==,
       }
     engines: { node: ^12.16.0 || >=13.2.0 }
     peerDependencies:
       shiki: "*"
     dependencies:
+      hash-obj: 4.0.0
       parse-numeric-range: 1.3.0
-      shiki: 0.10.1
+      shiki: 0.14.7
     dev: false
 
   /remark-gfm@3.0.1:
@@ -8819,6 +9014,18 @@ packages:
       unified: 10.1.2
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /remark-math@5.1.1:
+    resolution:
+      {
+        integrity: sha512-cE5T2R/xLVtfFI4cCePtiRn+e6jKMtFDR3P8V3qpv8wpKjwvHoBA4eJzvX+nVrnlNy0911bdGmuspCSwetfYHw==,
+      }
+    dependencies:
+      "@types/mdast": 3.0.15
+      mdast-util-math: 2.0.2
+      micromark-extension-math: 2.1.2
+      unified: 10.1.2
     dev: false
 
   /remark-mdx@2.3.0:
@@ -8998,13 +9205,13 @@ packages:
       loose-envify: 1.4.0
     dev: false
 
-  /scroll-into-view-if-needed@2.2.31:
+  /scroll-into-view-if-needed@3.1.0:
     resolution:
       {
-        integrity: sha512-dGCXy99wZQivjmjIqihaBQNjryrz5rueJY7eHfTdyWEiR4ttYpsajb14rn9s5d4DY4EcY6+4+U/maARBXJedkA==,
+        integrity: sha512-49oNpRjWRvnU8NyGVmUaYG4jtTkNonFZI86MmGRDqBphEK2EXT9gdEUoQPZhuBM8yWHxCWbobltqYO5M4XrUvQ==,
       }
     dependencies:
-      compute-scroll-into-view: 1.0.20
+      compute-scroll-into-view: 3.1.0
     dev: false
 
   /section-matter@1.0.0:
@@ -9101,15 +9308,16 @@ packages:
       }
     engines: { node: ">=8" }
 
-  /shiki@0.10.1:
+  /shiki@0.14.7:
     resolution:
       {
-        integrity: sha512-VsY7QJVzU51j5o1+DguUd+6vmCmZ5v/6gYu4vyYAhzjuNQU6P/vmSy4uQaOhvje031qQMiW0d2BwgMH52vqMng==,
+        integrity: sha512-dNPAPrxSc87ua2sKJ3H5dQ/6ZaY8RNnaAqK+t0eG7p0Soi2ydiqbGOTaZCqaYvA/uZYfS1LJnemt3Q+mSfcPCg==,
       }
     dependencies:
+      ansi-sequence-parser: 1.1.1
       jsonc-parser: 3.3.1
       vscode-oniguruma: 1.7.0
-      vscode-textmate: 5.2.0
+      vscode-textmate: 8.0.0
     dev: false
 
   /signal-exit@3.0.7:
@@ -9186,6 +9394,16 @@ packages:
     dependencies:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
+  /sort-keys@5.1.0:
+    resolution:
+      {
+        integrity: sha512-aSbHV0DaBcr7u0PVHXzM6NbZNAtrr9sF6+Qfs9UUVG7Ll3jQ6hHi8F/xqIIcn2rvIVbr0v/2zyjSdwSV47AgLQ==,
+      }
+    engines: { node: ">=12" }
+    dependencies:
+      is-plain-obj: 4.1.0
     dev: false
 
   /source-map-js@1.2.1:
@@ -9805,6 +10023,14 @@ packages:
     engines: { node: ">=10" }
     dev: true
 
+  /type-fest@1.4.0:
+    resolution:
+      {
+        integrity: sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==,
+      }
+    engines: { node: ">=10" }
+    dev: false
+
   /typescript-json-schema@0.63.0:
     resolution:
       {
@@ -9874,17 +10100,20 @@ packages:
       vfile: 5.3.7
     dev: false
 
+  /unist-util-find-after@4.0.1:
+    resolution:
+      {
+        integrity: sha512-QO/PuPMm2ERxC6vFXEPtmAutOopy5PknD+Oq64gGwxKtk4xwo9Z97t9Av1obPmGU0IyTa6EKYUfTrK2QJS3Ozw==,
+      }
+    dependencies:
+      "@types/unist": 2.0.11
+      unist-util-is: 5.2.1
+    dev: false
+
   /unist-util-generated@2.0.1:
     resolution:
       {
         integrity: sha512-qF72kLmPxAw0oN2fwpWIqbXAVyEqUzDHMsbtPvOudIlUzXYFIeQIuxXQCRCFh22B7cixvU0MG7m3MW8FTq/S+A==,
-      }
-    dev: false
-
-  /unist-util-is@4.1.0:
-    resolution:
-      {
-        integrity: sha512-ZOQSsnce92GrxSqlnEEseX0gi7GH9zTJZ0p9dtu87WRb/37mMPO2Ilx1s/t9vBHrFhbgweUwb+t7cIn5dxPhZg==,
       }
     dev: false
 
@@ -9925,6 +10154,17 @@ packages:
       unist-util-visit: 4.1.2
     dev: false
 
+  /unist-util-remove@3.1.1:
+    resolution:
+      {
+        integrity: sha512-kfCqZK5YVY5yEa89tvpl7KnBBHu2c6CzMkqHUrlOqaRgGOMp0sMvwWOVrbAtj03KhovQB7i96Gda72v/EFE0vw==,
+      }
+    dependencies:
+      "@types/unist": 2.0.11
+      unist-util-is: 5.2.1
+      unist-util-visit-parents: 5.1.3
+    dev: false
+
   /unist-util-stringify-position@3.0.3:
     resolution:
       {
@@ -9932,16 +10172,6 @@ packages:
       }
     dependencies:
       "@types/unist": 2.0.11
-    dev: false
-
-  /unist-util-visit-parents@3.1.1:
-    resolution:
-      {
-        integrity: sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==,
-      }
-    dependencies:
-      "@types/unist": 2.0.11
-      unist-util-is: 4.1.0
     dev: false
 
   /unist-util-visit-parents@4.1.1:
@@ -9962,17 +10192,6 @@ packages:
     dependencies:
       "@types/unist": 2.0.11
       unist-util-is: 5.2.1
-    dev: false
-
-  /unist-util-visit@2.0.3:
-    resolution:
-      {
-        integrity: sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==,
-      }
-    dependencies:
-      "@types/unist": 2.0.11
-      unist-util-is: 4.1.0
-      unist-util-visit-parents: 3.1.1
     dev: false
 
   /unist-util-visit@3.1.0:
@@ -10138,6 +10357,27 @@ packages:
       - "@types/react-dom"
     dev: false
 
+  /vfile-location@4.1.0:
+    resolution:
+      {
+        integrity: sha512-YF23YMyASIIJXpktBa4vIGLJ5Gs88UB/XePgqPmTa7cDA+JeO3yclbpheQYCHjVHBn/yePzrXuygIL+xbvRYHw==,
+      }
+    dependencies:
+      "@types/unist": 2.0.11
+      vfile: 5.3.7
+    dev: false
+
+  /vfile-matter@3.0.1:
+    resolution:
+      {
+        integrity: sha512-CAAIDwnh6ZdtrqAuxdElUqQRQDQgbbIrYtDYI8gCjXS1qQ+1XdLoK8FIZWxJwn0/I+BkSSZpar3SOgjemQz4fg==,
+      }
+    dependencies:
+      "@types/js-yaml": 4.0.9
+      is-buffer: 2.0.5
+      js-yaml: 4.1.0
+    dev: false
+
   /vfile-message@3.1.4:
     resolution:
       {
@@ -10189,10 +10429,17 @@ packages:
       }
     dev: false
 
-  /vscode-textmate@5.2.0:
+  /vscode-textmate@8.0.0:
     resolution:
       {
-        integrity: sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==,
+        integrity: sha512-AFbieoL7a5LMqcnOF04ji+rpXadgOXnZsxQr//r83kLPr7biP7am3g9zbaZIaBGwBRWeSvoMD4mgPdX3e4NWBg==,
+      }
+    dev: false
+
+  /web-namespaces@2.0.1:
+    resolution:
+      {
+        integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==,
       }
     dev: false
 
@@ -10367,7 +10614,6 @@ packages:
         integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==,
       }
     engines: { node: ">=10" }
-    dev: true
 
   /zod-prisma-types@3.1.6:
     resolution:


### PR DESCRIPTION
The SWC website looks weird on devices that have Inter installed as their UI font because `nextra-theme-docs` enables the `ss06` font feature by default until version 2.2.15. this fixes that issue by bumping `nextra` to v2.2.20. resolves #247 

before
![image](https://github.com/user-attachments/assets/10b1477b-018c-4cac-b93f-83537abc5bba)

after
![image](https://github.com/user-attachments/assets/e5ddfbc8-1764-431f-b2ad-c5efd7a30c2b)
