### PR TITLE
Update wasm-wasi target to wasm-wasip1

### DIFF
--- a/apps/website/pages/docs/plugin/ecmascript/getting-started.mdx
+++ b/apps/website/pages/docs/plugin/ecmascript/getting-started.mdx
@@ -33,10 +33,10 @@ You can follow instructions at ['Install Rust' page from the official rust websi
 SWC supports two kinds of `.wasm` files.
 Those are
 
-- wasm32-wasi
+- wasm32-wasip1
 - wasm32-unknown-unknown
 
-In this guide, we will use `wasm-wasi` as a target.
+In this guide, we will use `wasm-wasip1` as a target.
 
 #### Install `swc_cli`
 
@@ -60,9 +60,9 @@ SWC CLI supports creating a new plugin project.
 Run
 
 ```sh
-swc plugin new --target-type wasm32-wasi my-first-plugin
+swc plugin new --target-type wasm32-wasip1 my-first-plugin
 # You should to run this
-rustup target add wasm32-wasi
+rustup target add wasm32-wasip1
 ```
 
 to create a new plugin, and open `my-first-plugin` with your preferred rust IDE.


### PR DESCRIPTION
Updates the WASM target `wasm-wasi` to `wasm-wasip1` as it's now deprecated and exchanged for `wasm-wasip1`.

More to read here:
https://doc.rust-lang.org/nightly/rustc/platform-support/wasm32-wasip1.html#wasm32-wasip1