### PR TITLE
fix: double dash arguments in cli.mdx

### DIFF
--- a/apps/website/content/docs/usage/cli.mdx
+++ b/apps/website/content/docs/usage/cli.mdx
@@ -39,7 +39,7 @@ npx swc ./my-dir -d output
 
 ## Options
 
-### --filename (-f)
+### `--filename` (-f)
 
 Filename to use when reading from stdin. This will be used in source maps and errors.
 
@@ -47,7 +47,7 @@ Filename to use when reading from stdin. This will be used in source maps and er
 npx swc -f input.js
 ```
 
-### --config-file
+### `--config-file`
 
 Path to a `.swcrc` file to use.
 
@@ -55,7 +55,7 @@ Path to a `.swcrc` file to use.
 npx swc input.js --config-file .swcrc
 ```
 
-### --env-name
+### `--env-name`
 
 The name of the 'env' to use when loading configs and plugins. Defaults to the value of `SWC_ENV`, or else `NODE_ENV`, or else `development`.
 
@@ -63,7 +63,7 @@ The name of the 'env' to use when loading configs and plugins. Defaults to the v
 npx swc input.js --env-name='test'
 ```
 
-### --no-swcrc
+### `--no-swcrc`
 
 Whether or not to look up `.swcrc` files.
 
@@ -71,7 +71,7 @@ Whether or not to look up `.swcrc` files.
 npx swc input.js --no-swcrc
 ```
 
-### --ignore
+### `--ignore`
 
 List of glob paths to **not** compile.
 
@@ -89,7 +89,7 @@ Example:
 npx swc src --only **/*.js
 ```
 
-### --watch (-w)
+### `--watch` (-w)
 
 To automatically recompile files on changes, install `chokidar`:
 
@@ -103,7 +103,7 @@ Then, add the `-w` flag:
 npx swc input.js -w
 ```
 
-### --quiet (-q)
+### `--quiet` (-q)
 
 Suppress compilation output.
 
@@ -111,7 +111,7 @@ Suppress compilation output.
 npx swc input.js -q
 ```
 
-### --source-maps (-s)
+### `--source-maps` (-s)
 
 Values: `true|false|inline|both`
 
@@ -119,7 +119,7 @@ Values: `true|false|inline|both`
 npx swc input.js -s
 ```
 
-### --source-map-target
+### `--source-map-target`
 
 Define the `file` for the source map.
 
@@ -127,15 +127,15 @@ Define the `file` for the source map.
 npx swc input.js -s --source-map-target input.map.js
 ```
 
-### --source-file-name
+### `--source-file-name`
 
 Set `sources[0]` on returned source map
 
-### --source-root
+### `--source-root`
 
 The root from which all sources are relative.
 
-### --out-file (-o)
+### `--out-file` (-o)
 
 Compile all input files into a single file.
 
@@ -143,7 +143,7 @@ Compile all input files into a single file.
 npx swc input.js -o output.js
 ```
 
-### --out-dir (-d)
+### `--out-dir` (-d)
 
 Compile an input directory of modules into an output directory.
 
@@ -151,7 +151,7 @@ Compile an input directory of modules into an output directory.
 npx swc src -d dist
 ```
 
-### --copy-files (-D)
+### `--copy-files` (-D)
 
 When compiling a directory, copy over non-compilable files.
 
@@ -159,7 +159,7 @@ When compiling a directory, copy over non-compilable files.
 npx swc src --copy-files
 ```
 
-### --include-dotfiles
+### `--include-dotfiles`
 
 Include dotfiles when compiling and copying non-compilable files.
 
@@ -167,7 +167,7 @@ Include dotfiles when compiling and copying non-compilable files.
 npx swc src --include-dotfiles
 ```
 
-### --config (-C)
+### `--config` (-C)
 
 Override a config from `.swcrc` file.
 
@@ -175,7 +175,7 @@ Override a config from `.swcrc` file.
 npx swc src -C module.type=amd -C module.moduleId=hello
 ```
 
-### --sync
+### `--sync`
 
 Invoke swc synchronously. Useful for debugging.
 
@@ -183,7 +183,7 @@ Invoke swc synchronously. Useful for debugging.
 npx swc src --sync
 ```
 
-### --log-watch-compilation
+### `--log-watch-compilation`
 
 Log a message when a watched file is successfully compiled.
 
@@ -191,11 +191,11 @@ Log a message when a watched file is successfully compiled.
 npx swc input.js --log-watch-compilation
 ```
 
-### --extensions
+### `--extensions`
 
 Use specific extensions.
 
-### --strip-leading-paths
+### `--strip-leading-paths`
 
 Remove the leading directory (including all parent relative paths) when building the final output path. As an example it compiles all modules under `src` folder to `dist` folder, without create the `src` folder inside of `dist`.
 
@@ -242,7 +242,7 @@ swcDir({
 
 Please note that when using `callbacks`, the `--quiet (-q)` will always be true.
 
-### --out-file-extension
+### `--out-file-extension`
 
 Use a specific extension for the output files.
 


### PR DESCRIPTION
Wrap double dash (--) arguments with code block prevents replacing it with joined character on website + improves consitency with existing '--only' argument

Spent good 5 min figuring out why copy-pasted argument from official docs doesn't work, until noticed that double dash magically transformed into the single long dash character (possibly markdown lib bug) 

![Screenshot 2025-05-06 at 12 31 10](https://github.com/user-attachments/assets/a39c3632-625a-4001-bc01-1566ec20c502)
