### PR TITLE
Update jest.mdx

### DIFF
--- a/apps/website/content/docs/usage/jest.mdx
+++ b/apps/website/content/docs/usage/jest.mdx
@@ -2,7 +2,7 @@ import { Callout, Tabs, Tab } from 'nextra/components'
 
 # @swc/jest
 
-To make your Jest tests run faster, you can swap out the default JavaScript-based runner (`ts-jest`) for a [drop-in Rust replacement](https://github.com/swc-project/jest) using SWC.
+To make your Jest tests run faster, you can swap out the default JavaScript-based runner (`ts-jest`) for a [drop-in Rust replacement](https://github.com/swc-project/pkgs/tree/main/packages/jest) using SWC.
 
 ## Installation
 


### PR DESCRIPTION
Updating the link to the @swc/jest package.

Before it was linking to the archived jest package, now it links to the https://github.com/swc-project/pkgs/tree/main/packages/jest - current code location for the package.