### PR TITLE
Improve docs on using `"externalHelpers": true`

### DIFF
--- a/apps/website/content/docs/configuration/compilation.mdx
+++ b/apps/website/content/docs/configuration/compilation.mdx
@@ -208,11 +208,22 @@ Enable bugfix passes.
 
 The output code may depend on helper functions to support the target environment. By default, a helper function is inlined into the output files where it is required.
 
-You can use helpers from an external module by enabling `externalHelpers` and the helpers code will be imported by the output files from `node_modules/@swc/helpers`.
+By setting `"externalHelpers": true` SWC will inject import statements for these helpers from the `@swc/helpers` package instead of inlining them.
 
 While bundling, this option will greatly reduce your file size.
 
 You must add `@swc/helpers` as a dependency in addition to `@swc/core`.
+
+<Callout emoji="⚠️">
+When using `externalHelpers`, you might want to also configure [`"isModule": "unknown"`](#ismodule).
+
+By default, SWC will inject helpers methods with ESM style imports.
+
+So if your file is a commonjs module for example, then SWC will still inject ESM import statements for the helper methods and you'll have a file with mixed ESM and CommonJS imports which can lead to runtime errors.
+
+Setting `"isModule": "unknown"` will make SWC infer the module type of each file by reading it's import/export syntax and inject the helper imports with esm/commojs import statements accordingly.
+
+</Callout>
 
 ## jsc.parser
 

--- a/apps/website/public/schema.json
+++ b/apps/website/public/schema.json
@@ -47,6 +47,10 @@
         "preserveImportMeta": {
           "type": "boolean"
         },
+        "resolveFully": {
+          "description": "If set to true, This will resolve top .mjs",
+          "type": "boolean"
+        },
         "strict": {
           "description": "By default, when using exports with babel a non-enumerable `__esModule`\nproperty is exported. In some cases this property is used to determine\nif the import is the default export or if it contains the default export.\n\nIn order to prevent the __esModule property from being exported, you\n can set the strict option to true.\n\nDefaults to `false`.",
           "type": "boolean"
@@ -209,6 +213,10 @@
         "preserveImportMeta": {
           "type": "boolean"
         },
+        "resolveFully": {
+          "description": "If set to true, This will resolve top .mjs",
+          "type": "boolean"
+        },
         "strict": {
           "description": "By default, when using exports with babel a non-enumerable `__esModule`\nproperty is exported. In some cases this property is used to determine\nif the import is the default export or if it contains the default export.\n\nIn order to prevent the __esModule property from being exported, you\n can set the strict option to true.\n\nDefaults to `false`.",
           "type": "boolean"
@@ -336,6 +344,10 @@
           "type": "string"
         },
         "preserveImportMeta": {
+          "type": "boolean"
+        },
+        "resolveFully": {
+          "description": "If set to true, This will resolve top .mjs",
           "type": "boolean"
         },
         "strict": {
@@ -482,9 +494,21 @@
           "type": "boolean"
         },
         "comments": {
+          "anyOf": [
+            {
+              "properties": {
+                "regex": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "enum": ["all", false, "some"]
+            }
+          ],
           "default": false,
-          "description": "- `false`: removes all comments\n- `'some'`: preserves some comments\n- `'all'`: preserves all comments",
-          "enum": ["all", false, "some"]
+          "description": "- `false`: removes all comments\n- `'some'`: preserves some comments\n- `'all'`: preserves all comments\n- `{ regex: string }`: preserves comments that match the regex"
         },
         "ecma": {
           "$ref": "#/definitions/TerserEcmaVersion",
@@ -708,6 +732,17 @@
         "minify": {
           "$ref": "#/definitions/JsMinifyOptions"
         },
+        "output": {
+          "properties": {
+            "charset": {
+              "default": "'utf8'",
+              "description": "This can be used to keep the output ascii-only.\nIf this option is set, `minify.format.asciiOnly` will be ignored.",
+              "enum": ["ascii", "utf8"],
+              "type": "string"
+            }
+          },
+          "type": "object"
+        },
         "parser": {
           "$ref": "#/definitions/ParserConfig",
           "description": "Defaults to EsParserConfig"
@@ -818,6 +853,10 @@
           "type": "string"
         },
         "preserveImportMeta": {
+          "type": "boolean"
+        },
+        "resolveFully": {
+          "description": "If set to true, This will resolve top .mjs",
           "type": "boolean"
         },
         "strict": {
@@ -1177,7 +1216,19 @@
           "type": "boolean"
         },
         "comments": {
-          "enum": ["all", false, "some"]
+          "anyOf": [
+            {
+              "properties": {
+                "regex": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "enum": ["all", false, "some"]
+            }
+          ]
         },
         "ecma": {
           "$ref": "#/definitions/TerserEcmaVersion"
@@ -1349,6 +1400,10 @@
           "type": "string"
         },
         "preserveImportMeta": {
+          "type": "boolean"
+        },
+        "resolveFully": {
+          "description": "If set to true, This will resolve top .mjs",
           "type": "boolean"
         },
         "strict": {


### PR DESCRIPTION
When you set `"externalHelpers": true`, SWC will inject ESM import statements to the top of the file, regardless of if this module is commonjs or ESM.

This can mess up commonjs files because they'd now have mixed import syntaxes.

This can be fixed by setting `"isModule": "unkown"`.

So i've added a warning explaining that and pointing the user to the right direction.

Resloves: #299