### PR TITLE
docs: update Rspack links

### DIFF
--- a/apps/website/content/docs/configuration/bundling.mdx
+++ b/apps/website/content/docs/configuration/bundling.mdx
@@ -3,7 +3,7 @@ import { Callout } from 'nextra/components'
 # Bundling Configuration
 
 <Callout emoji="🚧">
-  This feature will be dropped in v2, in favor of SWC-based bundlers like [Parcel 2](https://parceljs.org/), [Turbopack](https://turbo.build/pack/docs), [rspack](https://rspack.dev/), [fe-farm](https://www.farmfe.org/).
+  This feature will be dropped in v2, in favor of SWC-based bundlers like [Parcel 2](https://parceljs.org/), [Turbopack](https://turbo.build/pack/docs), [Rspack](https://rspack.rs/), [fe-farm](https://www.farmfe.org/).
 
 Please use one of the bundlers instead.
 

--- a/apps/website/content/docs/usage/bundling.mdx
+++ b/apps/website/content/docs/usage/bundling.mdx
@@ -3,7 +3,7 @@ import { Callout, Tab, Tabs } from 'nextra/components'
 # Bundling (swcpack)
 
 <Callout emoji="🚧">
-  This feature will be dropped in v2, in favor of SWC-based bundlers like [Parcel 2](https://parceljs.org/), [Turbopack](https://turbo.build/pack/docs), [rspack](https://rspack.dev/), [fe-farm](https://www.farmfe.org/).
+  This feature will be dropped in v2, in favor of SWC-based bundlers like [Parcel 2](https://parceljs.org/), [Turbopack](https://turbo.build/pack/docs), [Rspack](https://rspack.rs/), [fe-farm](https://www.farmfe.org/).
 
 Please use one of the bundlers instead.
 

--- a/apps/website/content/docs/usage/swc-loader.mdx
+++ b/apps/website/content/docs/usage/swc-loader.mdx
@@ -4,7 +4,7 @@ import { Callout, Tabs, Tab } from 'nextra/components'
 
 This module allows you to use SWC with webpack.
 
-For Rspack users, you can use Rspack's [builtin:swc-loader](https://rspack.dev/guide/features/builtin-swc-loader), without the need to install the swc-loader package.
+For Rspack users, you can use Rspack's [builtin:swc-loader](https://rspack.rs/guide/features/builtin-swc-loader), without the need to install the swc-loader package.
 
 ## Installation
 

--- a/apps/website/content/index.mdx
+++ b/apps/website/content/index.mdx
@@ -69,10 +69,9 @@ npx swc ./file.js
 SWC is designed to be extensible. Currently, there is support for:
 
 - Compilation
-- Bundling (`swcpack`, under development)
 - Minification
 - Transforming with WebAssembly
-- Usage inside webpack (`swc-loader`)
+- Usage inside webpack and Rspack (`swc-loader`)
 - Improving Jest performance (`@swc/jest`)
 - Custom Plugins
 


### PR DESCRIPTION
## Summary

- update Rspack links (`rspack.dev` -> `rspack.rs`)
- remove `swcpack` from homepage (dropped)