### PR TITLE
Add SWC plugin registration docs and entry links

### DIFF
--- a/apps/plugins/app/(home)/page.tsx
+++ b/apps/plugins/app/(home)/page.tsx
@@ -23,9 +23,20 @@ const Home: FC = () => (
         </p>
       </div>
       <RuntimeVersionSelector />
-      <Button variant="link" asChild>
-        <Link href="/versions/range">or see all versions</Link>
-      </Button>
+      <div className="flex flex-col items-center">
+        <Button variant="link" asChild>
+          <Link href="/versions/range">or see all versions</Link>
+        </Button>
+        <Button variant="link" asChild>
+          <Link
+            href="https://swc.rs/docs/plugin/registering-plugins"
+            target="_blank"
+            rel="noreferrer"
+          >
+            Registration guide
+          </Link>
+        </Button>
+      </div>
     </div>
   </main>
 );

--- a/apps/plugins/app/versions/layout.tsx
+++ b/apps/plugins/app/versions/layout.tsx
@@ -4,25 +4,33 @@ import { Logo } from "../../components/logo";
 import { RuntimeVersionSelector } from "../../components/runtime-version-selector";
 
 type ResultsLayoutProps = {
-    children: ReactNode;
+  children: ReactNode;
 };
 
 const ResultsLayout: FC<ResultsLayoutProps> = ({ children }) => {
-    return (
-        <>
-            <nav className="bg-background/90 sticky top-0 z-50 border-b px-4 py-2 backdrop-blur-md">
-                <div className="container flex items-center justify-between">
-                    <Link href="/">
-                        <Logo className="h-5" />
-                    </Link>
-                    <div>
-                        <RuntimeVersionSelector />
-                    </div>
-                </div>
-            </nav>
-            <div className="container py-8">{children}</div>
-        </>
-    );
+  return (
+    <>
+      <nav className="bg-background/90 sticky top-0 z-50 border-b px-4 py-2 backdrop-blur-md">
+        <div className="container flex items-center justify-between">
+          <Link href="/">
+            <Logo className="h-5" />
+          </Link>
+          <div className="flex items-center gap-4">
+            <Link
+              href="https://swc.rs/docs/plugin/registering-plugins"
+              target="_blank"
+              rel="noreferrer"
+              className="text-muted-foreground text-sm underline-offset-4 hover:underline"
+            >
+              Registration guide
+            </Link>
+            <RuntimeVersionSelector />
+          </div>
+        </div>
+      </nav>
+      <div className="container py-8">{children}</div>
+    </>
+  );
 };
 
 export default ResultsLayout;

--- a/apps/website/content/docs/plugin/_meta.js
+++ b/apps/website/content/docs/plugin/_meta.js
@@ -2,4 +2,5 @@ export default {
   "selecting-swc-core": "Selecting swc_core",
   ecmascript: "ECMAScript",
   publishing: "Publishing",
+  "registering-plugins": "Registering Plugins",
 };

--- a/apps/website/content/docs/plugin/publishing.mdx
+++ b/apps/website/content/docs/plugin/publishing.mdx
@@ -2,6 +2,12 @@
 
 If you prefer reading codes, you can refer to [the repository for official plugins](https://github.com/swc-project/plugins).
 
+## Register on plugins.swc.rs
+
+After publishing your plugin package, add it to the plugin crawler index so it appears on [plugins.swc.rs](https://plugins.swc.rs).
+
+See [Registering plugins](./registering-plugins) for the step-by-step guide.
+
 ## Creating a npm package
 
 ### Building a plugin as a wasm

--- a/apps/website/content/docs/plugin/registering-plugins.mdx
+++ b/apps/website/content/docs/plugin/registering-plugins.mdx
@@ -1,0 +1,36 @@
+# Registering plugins on plugins.swc.rs
+
+If you want your Wasm plugin to appear on [plugins.swc.rs](https://plugins.swc.rs), submit a pull request to [swc-project/crawl-core-version](https://github.com/swc-project/crawl-core-version/tree/main/pkgs/plugins).
+
+The crawler reads plugin definitions from [`pkgs/plugins/*.yml`](https://github.com/swc-project/crawl-core-version/tree/main/pkgs/plugins).
+
+## 1. Add a `.yml` file under `pkgs/plugins`
+
+Create a file like `pkgs/plugins/your-plugin.yml`:
+
+```yml
+repo: https://github.com/your-org/your-plugin-repo.git
+packages:
+  - "@your-org/swc-plugin-foo"
+  - "@your-org/swc-plugin-bar"
+```
+
+## 2. Open a pull request
+
+Commit the new `.yml` file and open a PR against `main` in `crawl-core-version`.
+
+## Rules and notes
+
+- Only files ending with `.yml` are crawled.
+- Each entry in `packages` must exactly match the npm package name.
+- A single file can include multiple npm packages from the same repository.
+- `repo` should be a cloneable Git repository URL.
+
+## When will it show up on plugins.swc.rs?
+
+After your PR is merged, data is updated by the [`Auto Update` workflow](https://github.com/swc-project/crawl-core-version/blob/main/.github/workflows/auto-update.yml) in `crawl-core-version` (scheduled daily, and also runnable manually). Once that update runs, your plugin data can appear on `plugins.swc.rs`.
+
+## See also
+
+- [Publishing plugins](./publishing)
+- [Selecting swc_core](./selecting-swc-core)


### PR DESCRIPTION
## Summary
- add a new docs page at `/docs/plugin/registering-plugins` explaining how to register plugins for `plugins.swc.rs`
- add cross-linking from plugin publishing docs
- add `Registration guide` links in `plugins.swc.rs` home and `/versions/*` navigation

## Changes
- `apps/website/content/docs/plugin/registering-plugins.mdx` (new)
- `apps/website/content/docs/plugin/_meta.js`
- `apps/website/content/docs/plugin/publishing.mdx`
- `apps/plugins/app/(home)/page.tsx`
- `apps/plugins/app/versions/layout.tsx`

## Validation
- `pnpm --filter swc-site build` ✅
- `pnpm --filter swc-plugins lint` ❌ (existing Next lint config issue: `@next/next/no-html-link-for-pages` path undefined)
- `pnpm --filter swc-plugins build:next` ❌ (existing app issue: missing `./zod` export/module in `apps/plugins/lib/prisma`)
