### PR TITLE
docs: Add Flow usage guide

### DIFF
--- a/apps/website/content/docs/configuration/compilation.mdx
+++ b/apps/website/content/docs/configuration/compilation.mdx
@@ -242,6 +242,28 @@ Setting `"isModule": "unknown"` will make SWC infer the module type of each file
 }
 ```
 
+### flow
+
+```json filename=".swcrc" copy
+{
+  "jsc": {
+    "parser": {
+      "syntax": "flow",
+      "jsx": false,
+      "all": false,
+      "requireDirective": false,
+      "enums": false,
+      "decorators": false,
+      "components": false,
+      "patternMatching": false
+    }
+  }
+}
+```
+
+See the [Flow guide](/docs/usage/flow) for `@swc/core`, CLI, and `.swcrc`
+examples.
+
 ### ecmascript
 
 ```json filename=".swcrc" copy

--- a/apps/website/content/docs/usage/_meta.js
+++ b/apps/website/content/docs/usage/_meta.js
@@ -1,6 +1,7 @@
 export default {
   cli: "@swc/cli",
   core: "@swc/core",
+  flow: "Flow",
   wasm: "@swc/wasm",
   jest: "@swc/jest",
   "swc-loader": "swc-loader",

--- a/apps/website/content/docs/usage/cli.mdx
+++ b/apps/website/content/docs/usage/cli.mdx
@@ -37,6 +37,29 @@ npx swc ./file.js -o output.js
 npx swc ./my-dir -d output
 ```
 
+## Flow input
+
+To compile Flow code with the CLI, point `swc` at a `.swcrc` file that sets
+`jsc.parser.syntax` to `"flow"`:
+
+```json filename=".swcrc" copy
+{
+  "jsc": {
+    "parser": {
+      "syntax": "flow"
+    }
+  }
+}
+```
+
+```sh copy
+npx swc input.js --config-file .swcrc -o output.js
+```
+
+For JSX-flavored Flow files, set `jsx: true` and compile `.jsx` inputs with the
+same config. See the [Flow guide](/docs/usage/flow) for the full list of parser
+options.
+
 ## Options
 
 ### `--filename` (-f)

--- a/apps/website/content/docs/usage/core.mdx
+++ b/apps/website/content/docs/usage/core.mdx
@@ -33,6 +33,25 @@ swc
   });
 ```
 
+### Flow input
+
+To transform Flow code, set `jsc.parser.syntax` to `"flow"`. SWC will parse
+Flow syntax and strip type-only constructs as part of the transform pipeline.
+
+```js copy
+const swc = require("@swc/core");
+
+swc.transform("const value: number = 1;", {
+  jsc: {
+    parser: {
+      syntax: "flow",
+    },
+  },
+});
+```
+
+See the [Flow guide](/docs/usage/flow) for `.swcrc`, CLI, and parser options.
+
 ### transformSync
 
 Returns `{ code: string, map?: string }`
@@ -54,7 +73,7 @@ const swc = require('@swc/core')
 
 swc
   .parse("source code", {
-    syntax: "ecmascript", // "ecmascript" | "typescript"
+    syntax: "ecmascript", // "ecmascript" | "typescript" | "flow"
     comments: false,
     script: true,
 
@@ -107,7 +126,7 @@ export declare type ParseOptions = ParserConfig & {
   target?: JscTarget;
 };
 export declare type JscTarget = "es3" | "es5" | "es2015" | "es2016" | "es2017" | "es2018" | "es2019" | "es2020" | "es2021" | "es2022";
-export declare type ParserConfig = TsParserConfig | EsParserConfig;
+export declare type ParserConfig = TsParserConfig | EsParserConfig | FlowParserConfig;
 export interface TsParserConfig {
     syntax: "typescript";
     /**
@@ -122,6 +141,37 @@ export interface TsParserConfig {
      * Defaults to `false`
      */
     dynamicImport?: boolean;
+}
+export interface FlowParserConfig {
+    syntax: "flow";
+    /**
+     * Defaults to `false`.
+     */
+    jsx?: boolean;
+    /**
+     * Defaults to `false`.
+     */
+    all?: boolean;
+    /**
+     * Defaults to `false`.
+     */
+    requireDirective?: boolean;
+    /**
+     * Defaults to `false`.
+     */
+    enums?: boolean;
+    /**
+     * Defaults to `false`.
+     */
+    decorators?: boolean;
+    /**
+     * Defaults to `false`.
+     */
+    components?: boolean;
+    /**
+     * Defaults to `false`.
+     */
+    patternMatching?: boolean;
 }
 export interface EsParserConfig {
     syntax: "ecmascript";

--- a/apps/website/content/docs/usage/flow.mdx
+++ b/apps/website/content/docs/usage/flow.mdx
@@ -1,0 +1,127 @@
+# Flow
+
+SWC can parse Flow syntax and strip Flow type-only constructs during transform.
+
+This guide covers the most common ways to use Flow support:
+
+- `.swcrc`
+- `@swc/core`
+- `@swc/cli`
+
+## `.swcrc`
+
+Configure the parser with `syntax: "flow"`:
+
+```json filename=".swcrc" copy
+{
+  "$schema": "https://swc.rs/schema.json",
+  "jsc": {
+    "parser": {
+      "syntax": "flow",
+      "jsx": false
+    }
+  }
+}
+```
+
+For Flow code that uses a file pragma, enable `requireDirective`:
+
+```json filename=".swcrc" copy
+{
+  "jsc": {
+    "parser": {
+      "syntax": "flow",
+      "requireDirective": true
+    }
+  }
+}
+```
+
+Other supported Flow parser options map to the Flow parser configuration in SWC:
+
+```json filename=".swcrc" copy
+{
+  "jsc": {
+    "parser": {
+      "syntax": "flow",
+      "all": false,
+      "enums": false,
+      "decorators": false,
+      "components": false,
+      "patternMatching": false
+    }
+  }
+}
+```
+
+## `@swc/core`
+
+Use `jsc.parser.syntax = "flow"` when transforming Flow input:
+
+```js copy
+const swc = require("@swc/core");
+
+swc
+  .transform("const value: number = 1;", {
+    filename: "input.js",
+    jsc: {
+      parser: {
+        syntax: "flow",
+      },
+    },
+  })
+  .then((output) => {
+    output.code; // const value = 1;
+  });
+```
+
+You can also parse Flow syntax directly:
+
+```js copy
+const swc = require("@swc/core");
+
+swc
+  .parse("const value: number = 1;", {
+    syntax: "flow",
+  })
+  .then((module) => {
+    module.type;
+    module.body;
+  });
+```
+
+## `@swc/cli`
+
+Point the CLI at a `.swcrc` with `syntax: "flow"`:
+
+```json filename=".swcrc" copy
+{
+  "jsc": {
+    "parser": {
+      "syntax": "flow"
+    }
+  }
+}
+```
+
+```sh copy
+npx swc input.js --config-file .swcrc -o output.js
+```
+
+For JSX-flavored Flow input, set `jsx: true` and compile `.jsx` inputs with the
+same config:
+
+```json filename=".swcrc" copy
+{
+  "jsc": {
+    "parser": {
+      "syntax": "flow",
+      "jsx": true
+    }
+  }
+}
+```
+
+```sh copy
+npx swc component.jsx --config-file .swcrc -o component.js
+```


### PR DESCRIPTION
## Summary

This PR adds a canonical Flow usage guide and links the existing docs surfaces back to it.

## What Changed

- added `usage/flow.mdx` with `.swcrc`, `@swc/core`, and CLI examples
- linked the new guide from the core, CLI, and compilation docs
- updated the manual parser type snippet to include Flow parser config

## Why

The underlying Flow parse/strip support is now documented in [swc-project/swc#11778](https://github.com/swc-project/swc/pull/11778), and the website should provide one place for users to discover the supported configuration and usage patterns.

## Notes

- this PR intentionally leaves `apps/website/public/schema.json` unchanged until a published `@swc/types` release is available

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm build`
