### PR TITLE
Document default core-js version fallback for coreJs option

### DIFF
--- a/apps/website/content/docs/configuration/supported-browsers.mdx
+++ b/apps/website/content/docs/configuration/supported-browsers.mdx
@@ -96,6 +96,8 @@ Define ES features to skip to reduce bundle size. For example, your `.swcrc` cou
 
 The option has an effect when used alongside `mode: "usage"` or `mode: "entry"`. It is recommended to specify the minor version (E.g. `"3.22"`) otherwise `"3"` will be interpreted as `"3.0"` which may not include polyfills for the latest features.
 
+When `coreJs` is `undefined`, SWC falls back to `core-js@3.0.0`.
+
 ## Additional Options
 
 - `debug`: (_boolean_) defaults to `false`.


### PR DESCRIPTION
Summary
---

- Document that the coreJs option falls back to core-js@3.0.0 when left undefined, so users understand the implicit default behavior.
- Add the note directly after the existing coreJs description in the supported-browsers configuration docs.

Dependency
---

Implements about fallback version is [here](https://github.com/swc-project/swc/blob/d1c23476d039d546b2d9a1bdca68d696c6efb403/crates/swc_ecma_preset_env/src/lib.rs#L369-L373)