### PR TITLE
fix(website): center homepage and hide blog navigation

### DIFF
--- a/apps/website/docs/_nav.json
+++ b/apps/website/docs/_nav.json
@@ -8,10 +8,5 @@
     "text": "Playground",
     "link": "/playground/",
     "activeMatch": "^/playground/"
-  },
-  {
-    "text": "Blog",
-    "link": "/blog/perf-swc-vs-babel",
-    "activeMatch": "^/blog/"
   }
 ]

--- a/apps/website/src/styles/index.css
+++ b/apps/website/src/styles/index.css
@@ -69,6 +69,20 @@
   padding-top: 1rem;
 }
 
+@media (width >= 1280px) {
+  /* Balance the outline rail so the homepage stays centered in the viewport. */
+  .rp-doc-layout__container:has(.swc-home)
+    > .rp-doc-layout__sidebar-placeholder {
+    width: var(--rp-outline-width);
+    margin-left: var(--rp-outline-margin-right);
+  }
+
+  .rp-doc-layout__doc-container:has(.swc-home) {
+    padding-right: 1.5rem;
+    padding-left: 1.5rem;
+  }
+}
+
 .swc-home {
   width: 100%;
   max-width: 52rem;


### PR DESCRIPTION
## Summary

- center the homepage while preserving its on-page outline
- hide Blog from the primary navigation without removing blog routes

## Why

Rspress reserves different widths for the hidden left sidebar and visible right outline, shifting the homepage content left. The homepage now mirrors the outline rail on desktop so its content stays centered without affecting documentation pages.

## Validation

- `pnpm --filter swc-site build`
- `pnpm exec prettier --check apps/website/docs/index.mdx apps/website/docs/_nav.json apps/website/src/styles/index.css`
- generated HTML confirms the outline remains and Blog is absent from navigation

Repo-wide `turbo run lint test` remains blocked in the untouched plugins app by `@next/next/no-html-link-for-pages`: `The "path" argument must be of type string. Received undefined`.
