### PR TITLE
fix(website): adjust callout margin

### DIFF
--- a/apps/website/src/styles/index.css
+++ b/apps/website/src/styles/index.css
@@ -7,7 +7,7 @@
   border-radius: 8px;
   border: 1px solid;
   padding: 0.5rem 1rem 0.5rem 0;
-  margin: 1.5rem 0 0;
+  margin: 1.5rem 0;
   line-height: 1.75rem;
 }
 


### PR DESCRIPTION
## Summary

before

<img width="1537" height="848" alt="image" src="https://github.com/user-attachments/assets/e947cd47-4550-4bfe-b062-c337efae6794" />


after


<img width="1335" height="752" alt="image" src="https://github.com/user-attachments/assets/a41421f9-0bd5-487e-8905-d006c4543342" />

- apply symmetric vertical spacing to `swc-callout`

## Testing

- `pnpm exec prettier --check apps/website/src/styles/index.css`
- `pnpm --filter swc-site build`
